### PR TITLE
Mobile: prevent copy/select on shift-zone hint text

### DIFF
--- a/style.css
+++ b/style.css
@@ -1144,6 +1144,16 @@ line.grid-line--fade-out {
   visibility: visible;
 }
 
+@media (pointer: coarse) {
+  #board-shift-zone.visibleDisplay,
+  #board-shift-zone.visibleDisplay * {
+    user-select: none;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -webkit-touch-callout: none;
+  }
+}
+
 #board-shift-dismiss {
   position: absolute;
   top: 3px;


### PR DESCRIPTION
Apply user-select and -webkit-touch-callout under (pointer: coarse) when the board shift strip is visible in play.

Made-with: Cursor