### PR TITLE
Leaderboard cosmetics: column balance, ranked rows

### DIFF
--- a/js/leaderboard-ui.js
+++ b/js/leaderboard-ui.js
@@ -215,7 +215,7 @@ export function createLeaderboardController(rt) {
       const displayScoreCell = scoreNum === null ? "" : String(scoreNum);
       const displayTrophyCell = trophyStr || "";
 
-      const positionDisplay = String(index + 1);
+      const positionDisplay = `${index + 1}.`;
 
       [
         positionDisplay,

--- a/style.css
+++ b/style.css
@@ -1118,22 +1118,28 @@ line.grid-line--fade-out {
 
 #leaderboard-table th:nth-child(3),
 #leaderboard-table td:nth-child(3) {
-  width: 6ch;
+  width: 5.25ch;
 }
 
 #leaderboard-table th:nth-child(2),
 #leaderboard-table td:nth-child(2) {
-  width: calc((100% - 3.5ch - 6ch) * 0.36);
+  width: 7.5ch;
+  max-width: 7.5ch;
   min-width: 0;
+  box-sizing: border-box;
+  padding-left: 2px;
+  padding-right: 2px;
 }
 
 #leaderboard-table th:nth-child(4),
 #leaderboard-table td:nth-child(4) {
-  width: calc((100% - 3.5ch - 6ch) * 0.64);
+  width: auto;
   min-width: 0;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: clip;
+  padding-left: 4px;
+  padding-right: 4px;
 }
 
 #leaderboard-table th:nth-child(1),
@@ -1143,8 +1149,11 @@ line.grid-line--fade-out {
   text-align: center;
 }
 
+#leaderboard-table td:nth-child(2) {
+  text-align: left;
+}
+
 #leaderboard-table td:nth-child(1),
-#leaderboard-table td:nth-child(2),
 #leaderboard-table td:nth-child(3),
 #leaderboard-table td:nth-child(4) {
   text-align: center;
@@ -1205,14 +1214,14 @@ line.grid-line--fade-out {
   display: block;
   width: 100%;
   min-width: 0;
-  margin: 0 auto;
+  margin: 0;
   padding: 2px 4px;
   box-sizing: border-box;
   font: inherit;
   line-height: inherit;
   color: inherit;
   text-shadow: inherit;
-  text-align: center;
+  text-align: left;
   border: none;
   border-radius: 4px;
   background: rgba(0, 0, 0, 0.4);


### PR DESCRIPTION
- Fix name width (7.5ch), tighter rank/score; trophy uses remaining width
- Left-align player names and inline edit; rank column 3.5ch for N. labels
- Show rank as 1. 2. … in the table

Made-with: Cursor