### PR TITLE
Post-game copy score crossfade; full endgame tile fade-out

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -48,6 +48,7 @@ import { attachShiftGestures, ensureShiftPreviewElements } from "./shift-dom.js"
 import {
   getShowMessageDurationMs,
   clearWordLineTimers,
+  crossfadeCopyScoreToCopied,
   crossfadeWordmarkToHappyHunting,
   fadeInCurrentWordLine,
   showMessage,
@@ -185,6 +186,7 @@ export function initGame(ctx) {
   /** @type {Array<[string, number, number|string, string]> | null} */
   let demoLeaderboardRows = null;
   let demoLeaderboardSubmitUsed = false;
+  let copyScoreLineUsed = false;
   let tilePaletteTransitionTimer = null;
   const shiftState = {
     get pointerId() {
@@ -316,8 +318,11 @@ export function initGame(ctx) {
   });
 
   currentWordElement.addEventListener("click", function () {
-    if (!isGameActive) {
-      copyToClipboard(score, longestWord, diffDays);
+    if (isGameActive) return;
+    if (endgameUiShown && !copyScoreLineUsed) {
+      void copyScoreFirstTap();
+    } else {
+      copyScoreQuietTap();
     }
   });
 
@@ -570,6 +575,7 @@ export function initGame(ctx) {
 
   function updateCurrentWord() {
     if (ctx.state.wordLine.active) return;
+    if (endgameUiShown) return;
     currentWordElement.classList.remove("current-word--soft-hidden");
     if (!wordState.currentWord) {
       currentWordElement.textContent = "";
@@ -751,6 +757,7 @@ export function initGame(ctx) {
     bumpWordReplaceEpoch(ctx);
     endgamePostUiReady = false;
     endgameUiShown = false;
+    copyScoreLineUsed = false;
     postgameSequenceStarted = false;
     if (postgameCopyScoreTimer !== null) {
       window.clearTimeout(postgameCopyScoreTimer);
@@ -921,6 +928,7 @@ export function initGame(ctx) {
 
     endgamePostUiReady = false;
     endgameUiShown = false;
+    copyScoreLineUsed = false;
 
     ctx.state.shift.animating = false;
     ctx.state.shift.pointerId = null;
@@ -1013,22 +1021,48 @@ export function initGame(ctx) {
     requestAnimationFrame(syncLineOverlaySize);
   }
 
-  function copyToClipboard(score, longestWord, diffDays) {
-    playSound("copy", isMuted);
+  function buildClipboardScoreText() {
     let leaderboardText = "";
     if (playerPosition) {
       leaderboardText = `#${playerPosition} on `;
     }
-    navigator.clipboard
-      .writeText(
-        `${leaderboardText}wordhunter #${diffDays} 🏹${score}\n🏆 ${longestWord.toUpperCase()} 🏆\n${websiteLink}`
-      )
-      .then(function () {
-        alert("Score copied to clipboard");
+    return `${leaderboardText}wordhunter #${diffDays} 🏹${score}\n🏆 ${longestWord.toUpperCase()} 🏆\n${websiteLink}`;
+  }
+
+  function writeScoreToClipboardPromise() {
+    try {
+      const text = buildClipboardScoreText();
+      if (
+        navigator.clipboard &&
+        typeof navigator.clipboard.writeText === "function"
+      ) {
+        return navigator.clipboard.writeText(text);
+      }
+    } catch (err) {
+      return Promise.reject(err);
+    }
+    return Promise.reject(new Error("Clipboard API unavailable"));
+  }
+
+  function copyScoreQuietTap() {
+    playSound("copy", isMuted);
+    void writeScoreToClipboardPromise().catch((err) => {
+      console.error("Error copying score:", err);
+    });
+  }
+
+  function copyScoreFirstTap() {
+    if (copyScoreLineUsed) return;
+    copyScoreLineUsed = true;
+    playSound("copy", isMuted);
+    void writeScoreToClipboardPromise()
+      .catch((err) => {
+        console.error("Error copying score:", err);
       })
-      .catch(function (err) {
-        alert("FAIL\n\nUnable to copy score to clipboard");
-        console.log("Error in copyToClipboard:", err);
+      .finally(() => {
+        window.setTimeout(() => {
+          crossfadeCopyScoreToCopied(ctx);
+        }, 180);
       });
   }
 

--- a/js/leaderboard-ui.js
+++ b/js/leaderboard-ui.js
@@ -335,13 +335,13 @@ export function createLeaderboardController(rt) {
   function revealPostGameCopyScoreLine() {
     clearWordLineTimers(rt.ctx);
     refs().currentWordElement.classList.remove("current-word--valid-solve");
+    rt.setEndgameUiShown(true);
     fadeInCurrentWordLine(rt.ctx, "Copy Score", happyHuntingColor, {});
     rt.updateNextLetters();
     const { playerName, leaderboardButton } = refs();
     playerName.classList.add("hiddenDisplay");
     leaderboardButton.classList.add("hiddenDisplay");
     leaderboardButton.classList.add("leaderboard-action--concealed");
-    rt.setEndgameUiShown(true);
   }
 
   async function refreshLeaderboardFromApi(clicked) {

--- a/js/ui-word-line.js
+++ b/js/ui-word-line.js
@@ -50,6 +50,36 @@ export function beginCurrentWordMessageSession(ctx) {
   return myEpoch;
 }
 
+export function crossfadeCopyScoreToCopied(ctx) {
+  const el = ctx.refs.currentWordElement;
+  const fadeOutMs = CURRENT_WORD_FADE_MS;
+  const fadeInMs = CURRENT_WORD_BRIEF_FADE_IN_MS;
+
+  el.style.transition = "none";
+  void el.offsetHeight;
+  el.style.transition = `opacity ${fadeOutMs}ms ease-out`;
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      el.classList.add("current-word--soft-hidden");
+    });
+  });
+
+  window.setTimeout(() => {
+    el.style.transition = "none";
+    el.classList.add("current-word--soft-hidden");
+    el.textContent = "Score copied";
+    el.style.color = "#ffffff";
+    void el.offsetHeight;
+    el.style.transition = `opacity ${fadeInMs}ms ease-out`;
+    requestAnimationFrame(() => {
+      el.classList.remove("current-word--soft-hidden");
+    });
+    window.setTimeout(() => {
+      el.style.transition = "";
+    }, fadeInMs + 120);
+  }, fadeOutMs + 60);
+}
+
 export function fadeInCurrentWordLine(ctx, text, color, options = {}) {
   const currentWordElement = ctx.refs.currentWordElement;
   const wl = ctx.state.wordLine;

--- a/style.css
+++ b/style.css
@@ -1002,8 +1002,8 @@ line.grid-line--fade-out {
     opacity: 1;
   }
   100% {
-    filter: brightness(0.78);
-    opacity: 0.22;
+    filter: brightness(1);
+    opacity: 0;
   }
 }
 


### PR DESCRIPTION
- Replace copy alerts with in-line crossfade to Score copied
- Ensure clipboard helper always returns a Promise for .finally
- Set endgame UI flag before showing Copy Score line
- Endgame tile exit animation reaches opacity 0

Made-with: Cursor