### PR TITLE
fix: show blank tiles in shift ghost preview after endgame

### DIFF
--- a/js/grid-tiles.js
+++ b/js/grid-tiles.js
@@ -44,7 +44,11 @@ export function setTileText(el, tileText) {
   el.disabled = isBlankTile;
 }
 
-/** Empty peel slot visuals: instant hide unless `deferInstantHideForBlank` (endgame). */
+/**
+ * Peeled-slot styling for empty cells during play (`grid-button--slot-consumed*`).
+ * Blanks hide instantly unless `deferInstantHideForBlank` — used for end-game grid
+ * and shift ghost preview so blanks stay visible like normal inactive tiles.
+ */
 export function syncConsumedEmptySlotVisual(el, cellText, opts = {}) {
   const deferInstantHideForBlank = opts.deferInstantHideForBlank === true;
   const blank = normalizeTileText(cellText) === "";

--- a/js/shift-dom.js
+++ b/js/shift-dom.js
@@ -125,7 +125,9 @@ export function attachShiftGestures(ctx, host) {
       const ch = ctx.state.gameBoard[mapped.r][mapped.c];
       const el = tiles[t++];
       if (getTileText(el) !== ch) setTileText(el, ch);
-      syncConsumedEmptySlotVisual(el, ch);
+      syncConsumedEmptySlotVisual(el, ch, {
+        deferInstantHideForBlank: true,
+      });
     }
     showPreviewTiles(inner, need);
   }
@@ -160,51 +162,6 @@ export function attachShiftGestures(ctx, host) {
       const c = idx % n;
       return { r, c };
     });
-  }
-
-  function refillShiftPreviewFromBoardAfterCommit(horizontal, signedVis, k, opts) {
-    const reuseTileText = opts && opts.reuseTileText;
-    const n = GRID_SIZE;
-    const m = getGridCellMetrics();
-    const inner = shiftPreviewStrip
-      ? shiftPreviewStrip.querySelector(".shift-preview-inner")
-      : null;
-    if (!inner) return;
-    const need = n * k;
-    if (horizontal) {
-      if (signedVis > 0) {
-        setPreviewInnerGrid(inner, n, k, m);
-        inner.classList.remove("shift-preview-inner--col");
-        inner.classList.add("shift-preview-inner--row");
-        if (!reuseTileText) {
-          fillPreviewStripHorizontalLeft(inner, k);
-        }
-      } else {
-        setPreviewInnerGrid(inner, n, k, m);
-        inner.classList.remove("shift-preview-inner--col");
-        inner.classList.add("shift-preview-inner--row");
-        if (!reuseTileText) {
-          fillPreviewStripHorizontalRight(inner, k);
-        }
-      }
-    } else {
-      if (signedVis > 0) {
-        setPreviewInnerGrid(inner, k, n, m);
-        inner.classList.remove("shift-preview-inner--row");
-        inner.classList.add("shift-preview-inner--col");
-        if (!reuseTileText) {
-          fillPreviewStripVerticalTop(inner, k);
-        }
-      } else {
-        setPreviewInnerGrid(inner, k, n, m);
-        inner.classList.remove("shift-preview-inner--row");
-        inner.classList.add("shift-preview-inner--col");
-        if (!reuseTileText) {
-          fillPreviewStripVerticalBottom(inner, k);
-        }
-      }
-    }
-    showPreviewTiles(inner, need);
   }
 
   function updateShiftStageVisual(txVis, tyVis, horizontal, rawTx, rawTy) {


### PR DESCRIPTION
Use deferInstantHideForBlank when syncing preview strip tiles so blank cells match normal blank styling instead of peeled-slot instant hide.

Remove orphaned refillShiftPreviewFromBoardAfterCommit.

Clarify syncConsumedEmptySlotVisual doc comment.

Made-with: Cursor