### PR TITLE
fix: keep blank tiles visible after swipe (default defer peel-hide)

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -962,9 +962,7 @@ export function initGame(ctx) {
         "grid-button--endgame-flip-exit"
       );
       buttons[i].style.removeProperty("--endgame-flip-delay");
-      syncConsumedEmptySlotVisual(buttons[i], getTileText(buttons[i]), {
-        deferInstantHideForBlank: true,
-      });
+      syncConsumedEmptySlotVisual(buttons[i], getTileText(buttons[i]));
     }
     runGridTilePaletteTransition("toInactive", ENDGAME_TILE_TO_INACTIVE_MS, () => {
       const tiles = grid.getElementsByClassName("grid-button");

--- a/js/grid-tiles.js
+++ b/js/grid-tiles.js
@@ -45,12 +45,13 @@ export function setTileText(el, tileText) {
 }
 
 /**
- * Peeled-slot styling for empty cells during play (`grid-button--slot-consumed*`).
- * Blanks hide instantly unless `deferInstantHideForBlank` — used for end-game grid
- * and shift ghost preview so blanks stay visible like normal inactive tiles.
+ * Peeled-slot styling (`grid-button--slot-consumed*`).
+ * For blanks, `slot-consumed-instant` fully hides the tile. By default blanks
+ * stay visible; pass `deferInstantHideForBlank: false` only if you need that
+ * legacy instant-hide (unused in main game flow).
  */
 export function syncConsumedEmptySlotVisual(el, cellText, opts = {}) {
-  const deferInstantHideForBlank = opts.deferInstantHideForBlank === true;
+  const deferInstantHideForBlank = opts.deferInstantHideForBlank !== false;
   const blank = normalizeTileText(cellText) === "";
   if (blank) {
     el.classList.remove(
@@ -101,6 +102,7 @@ export function setTileTextAllowEmpty(el, tileText) {
   el.disabled = false;
 }
 
+/** Resync tiles from logical board — blank cells stay visible (no instant peel-hide). */
 export function syncDomFromBoard(grid, gameBoard, gridSize) {
   const n = gridSize;
   const tiles = grid.children;

--- a/js/shift-dom.js
+++ b/js/shift-dom.js
@@ -125,9 +125,7 @@ export function attachShiftGestures(ctx, host) {
       const ch = ctx.state.gameBoard[mapped.r][mapped.c];
       const el = tiles[t++];
       if (getTileText(el) !== ch) setTileText(el, ch);
-      syncConsumedEmptySlotVisual(el, ch, {
-        deferInstantHideForBlank: true,
-      });
+      syncConsumedEmptySlotVisual(el, ch);
     }
     showPreviewTiles(inner, need);
   }


### PR DESCRIPTION
Default syncConsumedEmptySlotVisual to defer instant hide for blanks so syncDomFromBoard/shift release no longer reapplies slot-consumed-instant during play. Simplify call sites.

Made-with: Cursor