### PR TITLE
Perfect Hunt starter hint: pulse glow and refreshed UX wiring.

### DIFF
--- a/js/board-logic.js
+++ b/js/board-logic.js
@@ -86,6 +86,47 @@ export function wordToTileLabelSequence(word) {
 }
 
 /**
+ * Row-major flat index for the Perfect Hunt pacing starter tile on `gameBoard`, or null.
+ * @param {string[][] | null | undefined} gameBoard
+ * @param {unknown} perfectHunt
+ * @param {number} orderIndex
+ * @param {boolean} onPace
+ * @param {number} gridSize
+ * @returns {number | null}
+ */
+export function computePerfectHuntStarterFlat(
+  gameBoard,
+  perfectHunt,
+  orderIndex,
+  onPace,
+  gridSize
+) {
+  const n = Math.max(1, Math.floor(Number(gridSize)) || 0);
+  if (
+    !onPace ||
+    !Array.isArray(perfectHunt) ||
+    perfectHunt.length === 0 ||
+    !Array.isArray(gameBoard)
+  ) {
+    return null;
+  }
+  if (orderIndex >= perfectHunt.length) return null;
+  const labels = wordToTileLabelSequence(String(perfectHunt[orderIndex] || ""));
+  if (!labels.length) return null;
+  const target = normalizeTileText(labels[0]);
+  for (let r = 0; r < n; r++) {
+    const row = gameBoard[r];
+    if (!Array.isArray(row)) continue;
+    for (let c = 0; c < n; c++) {
+      if (normalizeTileText(row[c]) === target) {
+        return r * n + c;
+      }
+    }
+  }
+  return null;
+}
+
+/**
  * Whether the same physical tile can be revisited for the j-th use of a letter:
  * need two different tile-labels in the subword strictly between the two
  * same-label positions (i & j). One letter between = not reusable.

--- a/js/game-context.js
+++ b/js/game-context.js
@@ -20,6 +20,11 @@ export function createGameContext() {
       perfectHuntOnPace: false,
       /** Index of next expected hunt word while on pace. */
       perfectHuntOrderIndex: 0,
+      /**
+       * Flat index of starter hint tile when set; skips redraw when unchanged (`refreshPerfectHuntHint`).
+       * @type {number | null}
+       */
+      perfectHuntHintFlat: null,
       wordLine: {
         active: false,
         /** @type {ReturnType<typeof setTimeout> | null} */

--- a/js/game.js
+++ b/js/game.js
@@ -22,6 +22,7 @@ import {
   PERFECT_HUNT_GAME_OVER_MESSAGE,
   PERFECT_ENDGAME_DEBOUNCE_BEFORE_GAME_OVER_MS,
   CHOIR_PLAYBACK_RATES_FOR_RANK,
+  WORD_LETTER_FLIP_MS,
 } from "./config.js";
 import {
   pickRandomScenarioMessage,
@@ -29,6 +30,7 @@ import {
   buildPerfectHuntMetadata,
   applyColumnShiftInPlace,
   applyRowShiftInPlace,
+  computePerfectHuntStarterFlat,
 } from "./board-logic.js";
 import {
   sounds,
@@ -153,6 +155,8 @@ export function initGame(ctx) {
     leaderboardButton,
     leaderboardDemoAdd,
   } = ctx.refs;
+
+  const PERFECT_HUNT_HINT_CLASS = "grid-button--perfect-hunt-hint";
 
   if (rulesNextLettersCountElement) {
     rulesNextLettersCountElement.textContent = String(NEXT_LETTERS_UI_COUNT);
@@ -383,8 +387,60 @@ export function initGame(ctx) {
     applyRowShiftInPlace(ctx.state.gameBoard, signedSteps, GRID_SIZE);
   }
 
+  function clearPerfectHuntHintVisual() {
+    const buttons = grid.getElementsByClassName("grid-button");
+    for (let i = 0; i < buttons.length; i++) {
+      buttons[i].classList.remove(PERFECT_HUNT_HINT_CLASS);
+    }
+    ctx.state.perfectHuntHintFlat = null;
+  }
+
+  /** @returns {number | null} row-major flat index, or null when no hint applies */
+  function computePerfectHuntHintFlat() {
+    return computePerfectHuntStarterFlat(
+      ctx.state.gameBoard,
+      ctx.state.perfectHunt,
+      ctx.state.perfectHuntOrderIndex,
+      ctx.state.perfectHuntOnPace,
+      GRID_SIZE
+    );
+  }
+
+  function refreshPerfectHuntHint() {
+    const nSq = GRID_SIZE * GRID_SIZE;
+
+    const nextFlat = computePerfectHuntHintFlat();
+    const prevFlat = ctx.state.perfectHuntHintFlat;
+
+    if (nextFlat == null) {
+      clearPerfectHuntHintVisual();
+      return;
+    }
+
+    for (let i = 0; i < nSq; i++) {
+      if (i !== nextFlat) {
+        grid.children[i]?.classList.remove(PERFECT_HUNT_HINT_CLASS);
+      }
+    }
+
+    const btn = grid.children[nextFlat];
+    if (!btn) {
+      ctx.state.perfectHuntHintFlat = null;
+      return;
+    }
+
+    if (prevFlat === nextFlat && btn.classList.contains(PERFECT_HUNT_HINT_CLASS)) {
+      ctx.state.perfectHuntHintFlat = nextFlat;
+      return;
+    }
+
+    btn.classList.add(PERFECT_HUNT_HINT_CLASS);
+    ctx.state.perfectHuntHintFlat = nextFlat;
+  }
+
   function syncDomFromBoard() {
     syncDomFromBoardTiles(grid, ctx.state.gameBoard, GRID_SIZE);
+    refreshPerfectHuntHint();
   }
 
   const shiftHost = {
@@ -551,6 +607,7 @@ export function initGame(ctx) {
     updateCurrentWord();
     updateNextLetters();
     scheduleDeferredGameAudioWarmup();
+    refreshPerfectHuntHint();
   }
 
   function generateGrid() {
@@ -574,6 +631,7 @@ export function initGame(ctx) {
     }
     ctx.state.perfectHuntWordsSubmitted = new Set();
     ctx.state.perfectHuntOrderIndex = 0;
+    ctx.state.perfectHuntHintFlat = null;
     ctx.state.perfectHuntOnPace =
       Array.isArray(p.perfect_hunt) && p.perfect_hunt.length > 0;
     if (rulesPerfectHuntTotalElement) {
@@ -607,6 +665,7 @@ export function initGame(ctx) {
 
     ensureShiftPreviewElements(ctx);
     syncLineOverlaySize();
+    refreshPerfectHuntHint();
     requestAnimationFrame(syncLineOverlaySize);
     requestAnimationFrame(lockGridSizeForSwipe);
   }
@@ -784,6 +843,8 @@ export function initGame(ctx) {
       const key = String(word || "").toLowerCase();
       return key === String(hunt[idx]).toLowerCase();
     },
+    refreshPerfectHuntHint,
+    clearPerfectHuntHintVisual,
   };
   const wordDrag = createWordDragHandlers(ctx, wordDragHost);
 
@@ -950,7 +1011,8 @@ export function initGame(ctx) {
         "grid-button--letter-swap-in",
         "grid-button--slot-consumed",
         "grid-button--slot-consumed-hunt-pace",
-        "grid-button--slot-consumed-instant"
+        "grid-button--slot-consumed-instant",
+        PERFECT_HUNT_HINT_CLASS
       );
       buttons[i].removeAttribute("data-selection-visits");
       buttons[i].style.color = "";
@@ -964,6 +1026,7 @@ export function initGame(ctx) {
       buttons[i].style.removeProperty("--endgame-flip-delay");
       syncConsumedEmptySlotVisual(buttons[i], getTileText(buttons[i]));
     }
+    ctx.state.perfectHuntHintFlat = null;
     runGridTilePaletteTransition("toInactive", ENDGAME_TILE_TO_INACTIVE_MS, () => {
       const tiles = grid.getElementsByClassName("grid-button");
       for (let i = 0; i < tiles.length; i++) {
@@ -1202,7 +1265,8 @@ export function initGame(ctx) {
         "grid-button--endgame-flip-exit",
         "grid-button--slot-consumed",
         "grid-button--slot-consumed-hunt-pace",
-        "grid-button--slot-consumed-instant"
+        "grid-button--slot-consumed-instant",
+        "grid-button--perfect-hunt-hint"
       );
     }
 

--- a/js/shift-dom.js
+++ b/js/shift-dom.js
@@ -21,9 +21,12 @@ import {
   computeShiftSnapPlan,
   computeShiftStageTransformString,
   gridInverseCompensateTranslateString,
+  computePerfectHuntStarterFlat,
 } from "./board-logic.js";
 import { getTileText, setTileText, syncConsumedEmptySlotVisual } from "./grid-tiles.js";
 import { unlockGameAudio, playSound } from "./audio.js";
+
+const SHIFT_PREVIEW_HUNT_HINT_CLASS = "shift-preview-tile--hunt-hint";
 
 export function ensureShiftPreviewElements(ctx) {
   const { shiftPreviewStrip } = ctx.refs;
@@ -96,6 +99,9 @@ export function attachShiftGestures(ctx, host) {
         inner.style.gridTemplateRows = "";
         inner.style.width = "";
         inner.style.height = "";
+        inner.querySelectorAll(".shift-preview-tile").forEach((el) => {
+          el.classList.remove(SHIFT_PREVIEW_HUNT_HINT_CLASS);
+        });
       }
     }
   }
@@ -119,6 +125,16 @@ export function attachShiftGestures(ctx, host) {
     const n = GRID_SIZE;
     const tiles = inner.querySelectorAll(".shift-preview-tile");
     const need = n * k;
+    const starterFlat = computePerfectHuntStarterFlat(
+      ctx.state.gameBoard,
+      ctx.state.perfectHunt,
+      ctx.state.perfectHuntOrderIndex,
+      ctx.state.perfectHuntOnPace,
+      n
+    );
+    for (let i = 0; i < tiles.length; i++) {
+      tiles[i].classList.remove(SHIFT_PREVIEW_HUNT_HINT_CLASS);
+    }
     let t = 0;
     for (let row = 0; row < need; row++) {
       const mapped = mapCellToBoard(row, n, k);
@@ -126,6 +142,11 @@ export function attachShiftGestures(ctx, host) {
       const el = tiles[t++];
       if (getTileText(el) !== ch) setTileText(el, ch);
       syncConsumedEmptySlotVisual(el, ch);
+      const mappedFlat = mapped.r * n + mapped.c;
+      el.classList.toggle(
+        SHIFT_PREVIEW_HUNT_HINT_CLASS,
+        starterFlat != null && mappedFlat === starterFlat
+      );
     }
     showPreviewTiles(inner, need);
   }

--- a/js/word-drag.js
+++ b/js/word-drag.js
@@ -191,6 +191,8 @@ export function createWordDragHandlers(ctx, host) {
     }
     st.wordReplaceLockGen = epoch;
 
+    host.clearPerfectHuntHintVisual?.();
+
     let phaseBStarted = false;
     let greenDoneCount = 0;
 
@@ -275,6 +277,7 @@ export function createWordDragHandlers(ctx, host) {
         }
         st.lastButton = null;
         st.wordReplaceLockGen = 0;
+        host.refreshPerfectHuntHint?.();
         window.setTimeout(() => {
           if (epoch !== st.wordReplaceEpoch) return;
           if (typeof onWordCommitAnimationsComplete === "function") {

--- a/style.css
+++ b/style.css
@@ -20,6 +20,23 @@
   /** Perfect-hunt on-pace word submit: bright tile fill (not the pale default active cell). */
   --hunt-pace-highlight-bg: #f5e2a2;
   --hunt-pace-highlight-text: #3d2800;
+  --perfect-hunt-starter-hint-orange-solid: #fe9216;
+  --perfect-hunt-starter-hint-glow-min: color-mix(
+    in srgb,
+    var(--perfect-hunt-starter-hint-orange-solid) 31%,
+    transparent
+  );
+  --perfect-hunt-starter-hint-glow-peak: color-mix(
+    in srgb,
+    var(--perfect-hunt-starter-hint-orange-solid) 46%,
+    transparent
+  );
+  --perfect-hunt-starter-hint-glow-static: color-mix(
+    in srgb,
+    var(--perfect-hunt-starter-hint-orange-solid) 37%,
+    transparent
+  );
+  --perfect-hunt-starter-hint-pulse-duration: 1.75s;
   --grid-button-text-color: white;
   --leaderboard-button-background-color: #ed3d02;
   --leaderboard-button-text-color: white;
@@ -752,6 +769,58 @@ html {
 .shift-preview-tile {
   pointer-events: none;
   cursor: default;
+}
+
+@keyframes perfectHuntStarterGlowPulse {
+  0%,
+  100% {
+    box-shadow: 0 0 9px 0 var(--perfect-hunt-starter-hint-glow-min);
+  }
+
+  50% {
+    box-shadow: 0 0 15px 2px var(--perfect-hunt-starter-hint-glow-peak);
+  }
+}
+
+.grid-button.grid-button--perfect-hunt-hint {
+  z-index: 2;
+}
+
+.grid-button.shift-preview-tile.shift-preview-tile--hunt-hint {
+  z-index: 1;
+  color: var(--grid-button-active-text-color);
+  border-color: var(--grid-button-active-border-color);
+}
+
+.grid-button.grid-button--perfect-hunt-hint::before,
+.grid-button.shift-preview-tile.shift-preview-tile--hunt-hint::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  z-index: 0;
+  animation: perfectHuntStarterGlowPulse var(--perfect-hunt-starter-hint-pulse-duration)
+    ease-in-out infinite;
+}
+
+.grid-button.grid-button--perfect-hunt-hint .tile-glyph,
+.grid-button.shift-preview-tile.shift-preview-tile--hunt-hint .tile-glyph {
+  position: relative;
+  z-index: 2;
+}
+
+.grid-button.grid-button--perfect-hunt-hint .tile-weight-badge,
+.grid-button.shift-preview-tile.shift-preview-tile--hunt-hint .tile-weight-badge {
+  z-index: 2;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .grid-button.grid-button--perfect-hunt-hint::before,
+  .grid-button.shift-preview-tile.shift-preview-tile--hunt-hint::before {
+    animation: none;
+    box-shadow: 0 0 11px 1px var(--perfect-hunt-starter-hint-glow-static);
+  }
 }
 
 #grid {


### PR DESCRIPTION
Expose starter-flat helpers from board-logic; tint ghost preview hunt tiles during shifts.

Animate starter highlighting only via layered orange pulse (::before box-shadow tokens); tile fill stays normal active chrome.

Drop post-word hint flip; call refreshPerfectHuntHint after replacements. Trim stale context comment.

Made-with: Cursor