### PR TITLE
Leaderboard: rotation puzzle id, Flask API contract, optional scoreValidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,26 +30,26 @@ npm test
 
 Feature modules (each takes `ctx` and/or small host/runtime objects):
 
-| Module                     | Role                                                                                                       |
-| -------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| `board-logic.js`           | Scoring, shifts, tile normalization (tested)                                                               |
-| `grid-tiles.js`            | Tile DOM helpers, `syncDomFromBoard`                                                                       |
-| `shift-gestures.js`        | Shift gesture state factory                                                                                |
-| `shift-dom.js`             | Shift preview, commit, pointers, grid lock hooks                                                           |
-| `word-play.js`             | Adjacency + selection visit depth on the grid                                                              |
-| `word-drag.js`             | Word selection, connector SVG, success/invalid choreography                                                |
-| `word-path.js`             | Path gradient helpers (tested)                                                                             |
-| `ui-word-line.js`          | Current-word line, messages, intro crossfade                                                               |
-| `leaderboard-lifecycle.js` | Demo leaderboard merge helpers (pure)                                                                      |
-| `leaderboard-ui.js`        | Table, overlay, API refresh, postgame copy-score flow                                                      |
-| `rules-dock.js`            | Rules overlay + mute wiring                                                                                |
-| `game-lifecycle.js`        | `loadWordhunterTextAssets`, `loadWordlistWordSet` (gamemaker only), `puzzleListIndex`, `calculateDiffDays` |
-| `audio.js`                 | Sound pools and playback                                                                                   |
-| `config.js`                | Constants and timings                                                                                      |
+| Module                     | Role                                                                                                             |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `board-logic.js`           | Scoring, shifts, tile normalization (tested)                                                                     |
+| `grid-tiles.js`            | Tile DOM helpers, `syncDomFromBoard`                                                                             |
+| `shift-gestures.js`        | Shift gesture state factory                                                                                      |
+| `shift-dom.js`             | Shift preview, commit, pointers, grid lock hooks                                                                 |
+| `word-play.js`             | Adjacency + selection visit depth on the grid                                                                    |
+| `word-drag.js`             | Word selection, connector SVG, success/invalid choreography                                                      |
+| `word-path.js`             | Path gradient helpers (tested)                                                                                   |
+| `ui-word-line.js`          | Current-word line, messages, intro crossfade                                                                     |
+| `leaderboard-lifecycle.js` | Demo leaderboard merge helpers (pure)                                                                            |
+| `leaderboard-ui.js`        | Table, overlay, API refresh, postgame copy-score flow                                                            |
+| `rules-dock.js`            | Rules overlay + mute wiring                                                                                      |
+| `game-lifecycle.js`        | `loadWordhunterTextAssets`, `loadWordlistWordSet` (gamemaker only), `puzzleListIndex`, `calculatePuzzleDayIndex` |
+| `audio.js`                 | Sound pools and playback                                                                                         |
+| `config.js`                | Constants and timings                                                                                            |
 
 ## Content and assets
 
-- **`text/`** — `wordlist.txt` and `puzzles.txt` (JSON Lines per puzzle: `starting_grid`, compact `next_letters` (typically 50 tokens, pads to `NEXT_LETTERS_LEN` = 66), `perfect_hunt` ×7; Σ min-tiles per row = **66**). Daily row: `puzzleListIndex` in `puzzle-calendar.js` (`PUZZLE_ROTATION_EPOCH`). Leaderboard / share `#` still use legacy `calculateDiffDays`.
+- **`text/`** — `wordlist.txt` and `puzzles.txt` (JSON Lines per puzzle: `starting_grid`, compact `next_letters` (typically 50 tokens, pads to `NEXT_LETTERS_LEN` = 66), `perfect_hunt` ×7; Σ min-tiles per row = **66**). Daily row: `puzzleListIndex` in `puzzle-calendar.js` (`PUZZLE_ROTATION_EPOCH`). Leaderboard path and share `#` use `calculatePuzzleDayIndex()` (same epoch).
 - **`sounds/`** — Game SFX referenced from `audio.js`.
 - **`style.css`** — Layout and theme.
 

--- a/js/config.js
+++ b/js/config.js
@@ -55,7 +55,12 @@ export const TILE_PALETTE_TRANSITION_SETTLE_MS = 120;
 export const CURRENT_WORD_FADE_MS = 220;
 export const CURRENT_WORD_MESSAGE_EXTRA_MS = 500;
 export const CURRENT_WORD_MESSAGE_ON_MS = 1100 + CURRENT_WORD_MESSAGE_EXTRA_MS;
-export const LEADERBOARD_USE_DEMO_DATA = true;
+export const LEADERBOARD_USE_DEMO_DATA = false;
+/** Trailing slash required; requests are `${LEADERBOARD_API_BASE}{puzzleId}`. */
+export const LEADERBOARD_API_BASE =
+  "https://johnriley81.pythonanywhere.com/leaderboard/";
+/** When true, POST includes `scoreValidation` (server `WORDHUNTER_VALIDATE_SCORE`). */
+export const LEADERBOARD_SUBMIT_SCORE_VALIDATION = false;
 export const LEADERBOARD_DEMO_INJECT_PERFECT_HUNT_ROW = true;
 export const LEADERBOARD_DEMO_INJECT_OVER_PERFECT_HUNT_ROW = true;
 export const LEADERBOARD_DEMO_OVER_PERFECT_SCORE_EXTRA = 777;

--- a/js/game-lifecycle.js
+++ b/js/game-lifecycle.js
@@ -1,5 +1,6 @@
-export { calculateDiffDays, puzzleListIndex } from "./puzzle-calendar.js";
 import { parsePuzzlesFileText } from "./puzzle-row-format.js";
+
+export { calculatePuzzleDayIndex, puzzleListIndex } from "./puzzle-calendar.js";
 
 /** Lowercase gameplay dictionary only — for gamemaker path validation without loading puzzles. */
 export async function loadWordlistWordSet() {

--- a/js/game.js
+++ b/js/game.js
@@ -14,6 +14,8 @@ import {
   TILE_PALETTE_TRANSITION_SETTLE_MS,
   ENDGAME_GRID_BATCH_FADE_MS,
   LEADERBOARD_USE_DEMO_DATA,
+  LEADERBOARD_API_BASE,
+  LEADERBOARD_SUBMIT_SCORE_VALIDATION,
   LEADERBOARD_OVERLAY_FADE_OUT_TOTAL_MS,
   ENDGAME_SOUND_FALLBACK_MS,
   GAME_OVER_FLASH_TIMES,
@@ -44,7 +46,7 @@ import {
   unlockGameAudio,
 } from "./audio.js";
 import {
-  calculateDiffDays,
+  calculatePuzzleDayIndex,
   loadWordhunterTextAssets,
   puzzleListIndex,
 } from "./game-lifecycle.js";
@@ -79,11 +81,15 @@ import {
   unlockGridSizeAfterSwipe as unlockGridSizeAfterSwipeCore,
 } from "./grid-layout.js";
 
+function cloneBoardSnapshotForLeaderboard(board) {
+  return board.map((row) => row.map((cell) => String(cell || "").toLowerCase()));
+}
+
 let isMouseDown = false;
 let isGameActive = false;
 let longestWord = "";
 let websiteLink = "https://wordhunter.io/";
-let leaderboardLink = "https://johnriley81.pythonanywhere.com/leaderboard/";
+const leaderboardLink = LEADERBOARD_API_BASE;
 let playerPosition;
 
 export function initGame(ctx) {
@@ -186,7 +192,8 @@ export function initGame(ctx) {
   let wordSet = new Set();
   /** @type {Array<{ starting_grid: string[][]; next_letters: string[]; perfect_hunt: string[]; perfect_hunt_starter_flats?: number[]; perfect_hunt_starter_tor_neighbors?: string[] }>} */
   let puzzles = [];
-  let diffDays = 0;
+  let leaderboardPuzzleId = 0;
+  let scoreValidationTurns = [];
   let isPaused = false;
   let isMuted = false;
 
@@ -563,6 +570,7 @@ export function initGame(ctx) {
     lockGridSizeForSwipe();
 
     score = 0;
+    scoreValidationTurns = [];
     wordState.currentWord = "";
     ctx.state.perfectHuntWordsSubmitted?.clear();
     ctx.state.perfectHuntOrderIndex = 0;
@@ -618,7 +626,8 @@ export function initGame(ctx) {
     while (grid.firstChild) {
       grid.removeChild(grid.firstChild);
     }
-    diffDays = calculateDiffDays();
+    leaderboardPuzzleId = calculatePuzzleDayIndex();
+    scoreValidationTurns = [];
     const p = puzzles[puzzleListIndex(puzzles.length)];
     const gridLetters = p.starting_grid;
     ctx.state.perfectHunt = p.perfect_hunt;
@@ -686,7 +695,7 @@ export function initGame(ctx) {
   }
 
   function generateNextLetters() {
-    diffDays = calculateDiffDays();
+    leaderboardPuzzleId = calculatePuzzleDayIndex();
     const p = puzzles[puzzleListIndex(puzzles.length)];
     nextLetters = p.next_letters.slice();
     return nextLetters;
@@ -868,6 +877,15 @@ export function initGame(ctx) {
     },
     refreshPerfectHuntHint,
     clearPerfectHuntHintVisual,
+    recordLeaderboardScoreTurn(word, replacementCount) {
+      if (!LEADERBOARD_SUBMIT_SCORE_VALIDATION) return;
+      const letters = cloneBoardSnapshotForLeaderboard(ctx.state.gameBoard);
+      scoreValidationTurns.push([
+        String(word || "").toLowerCase(),
+        letters,
+        replacementCount,
+      ]);
+    },
   };
   const wordDrag = createWordDragHandlers(ctx, wordDragHost);
 
@@ -879,7 +897,8 @@ export function initGame(ctx) {
     leaderboardLink,
     getScore: () => score,
     getLongestWord: () => longestWord,
-    getDiffDays: () => diffDays,
+    getLeaderboardPuzzleId: () => leaderboardPuzzleId,
+    getScoreValidationTurns: () => scoreValidationTurns,
     getIsMuted: () => isMuted,
     getIsGameActive: () => isGameActive,
     getEndgamePostUiReady: () => endgamePostUiReady,
@@ -1305,7 +1324,7 @@ export function initGame(ctx) {
     if (playerPosition) {
       leaderboardText = `#${playerPosition} on `;
     }
-    return `${leaderboardText}wordhunter #${diffDays} 🏹${score}\n🏆 ${longestWord.toUpperCase()} 🏆\n${websiteLink}`;
+    return `${leaderboardText}wordhunter #${leaderboardPuzzleId} 🏹${score}\n🏆 ${longestWord.toUpperCase()} 🏆\n${websiteLink}`;
   }
 
   function writeScoreToClipboardPromise() {

--- a/js/leaderboard-ui.js
+++ b/js/leaderboard-ui.js
@@ -1,5 +1,6 @@
 import {
   LEADERBOARD_USE_DEMO_DATA,
+  LEADERBOARD_SUBMIT_SCORE_VALIDATION,
   LEADERBOARD_DEMO_INJECT_PERFECT_HUNT_ROW,
   LEADERBOARD_DEMO_INJECT_OVER_PERFECT_HUNT_ROW,
   LEADERBOARD_DEMO_OVER_PERFECT_SCORE_EXTRA,
@@ -21,6 +22,61 @@ import {
 } from "./leaderboard-lifecycle.js";
 import { clearWordLineTimers, fadeInCurrentWordLine } from "./ui-word-line.js";
 import { unlockGameAudio } from "./audio.js";
+
+function normalizeLeaderboardRow(row) {
+  if (!Array.isArray(row)) return ["", 0, "", ""];
+  if (row.length >= 4) {
+    return [
+      String(row[0] ?? ""),
+      Number(row[1]) === 1 ? 1 : 0,
+      row[2],
+      String(row[3] ?? ""),
+    ];
+  }
+  if (row.length >= 3) {
+    return [String(row[0] ?? ""), 0, row[1], String(row[2] ?? "")];
+  }
+  return ["", 0, "", ""];
+}
+
+function normalizeLeaderboardRows(raw) {
+  if (!Array.isArray(raw)) return [];
+  return raw.map(normalizeLeaderboardRow);
+}
+
+function parsedFetchPayload(raw) {
+  if (raw == null || typeof raw !== "object" || !("body" in raw)) return raw;
+  const b = raw.body;
+  if (typeof b === "string") {
+    try {
+      return JSON.parse(b);
+    } catch {
+      return {};
+    }
+  }
+  return b ?? {};
+}
+
+function leaderboardRowsFromResponse(response, payload, didSubmit) {
+  if (!response.ok) {
+    if (
+      didSubmit &&
+      payload &&
+      typeof payload === "object" &&
+      Array.isArray(payload.top_10)
+    ) {
+      return payload.top_10;
+    }
+    console.error("Leaderboard request failed", response.status, payload);
+    return [];
+  }
+  if (didSubmit) {
+    return payload && typeof payload === "object" && Array.isArray(payload.top_10)
+      ? payload.top_10
+      : [];
+  }
+  return Array.isArray(payload) ? payload : [];
+}
 
 function leaderboardNumericScore(row) {
   const raw = row[2];
@@ -225,7 +281,9 @@ export function createLeaderboardController(rt) {
     leaderboardTable.innerHTML = "";
     const tbody = document.createElement("tbody");
 
-    const rows = mergeDemoLeaderboardPreviewRows(leaderboard);
+    const rows = mergeDemoLeaderboardPreviewRows(
+      normalizeLeaderboardRows(Array.isArray(leaderboard) ? leaderboard : [])
+    );
     const headerRow = document.createElement("tr");
     ["", "👤", "🏹", "🏆"].forEach((headerText) => {
       const th = document.createElement("th");
@@ -438,38 +496,50 @@ export function createLeaderboardController(rt) {
       leaderboardButton.style.backgroundColor = "gray";
     }
 
-    const requestURL = `${rt.leaderboardLink}${rt.getDiffDays()}`;
-    const requestOptions = {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-      },
-    };
+    try {
+      const requestURL = `${rt.leaderboardLink}${rt.getLeaderboardPuzzleId()}`;
+      const requestOptions = {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      };
 
-    const willSubmit =
-      rt.getScore() > SCORE_SUBMIT_THRESHOLD && playerName.value !== "";
-    if (willSubmit) {
-      requestOptions.method = "POST";
-      requestOptions.body = JSON.stringify({
-        player: playerName.value,
-        hard: false,
-        score: rt.getScore(),
-        trophy: rt.getLongestWord(),
-      });
+      const willSubmit =
+        rt.getScore() > SCORE_SUBMIT_THRESHOLD && playerName.value !== "";
+      if (willSubmit) {
+        const postBody = {
+          player: playerName.value,
+          score: rt.getScore(),
+          trophy: rt.getLongestWord(),
+        };
+        if (LEADERBOARD_SUBMIT_SCORE_VALIDATION) {
+          postBody.scoreValidation = rt.getScoreValidationTurns();
+        }
+        requestOptions.method = "POST";
+        requestOptions.body = JSON.stringify(postBody);
+      }
+
+      const response = await fetch(requestURL, requestOptions);
+      let raw = {};
+      try {
+        raw = await response.json();
+      } catch {}
+      const payload = parsedFetchPayload(raw);
+      const leaderboard = leaderboardRowsFromResponse(response, payload, willSubmit);
+
+      if (willSubmit && response.ok) {
+        rt.playSound("submit", rt.getIsMuted());
+      }
+
+      renderLeaderboardTable(leaderboard);
+    } finally {
+      if (clicked) {
+        playerName.disabled = false;
+        leaderboardButton.disabled = false;
+        leaderboardButton.style.backgroundColor = "";
+      }
     }
-
-    const response = await fetch(requestURL, requestOptions);
-    if (willSubmit && response.ok) {
-      rt.playSound("submit", rt.getIsMuted());
-    }
-    const data = await response.json();
-    const parsedBody = JSON.parse(data["body"]);
-    const leaderboard =
-      rt.getScore() > SCORE_SUBMIT_THRESHOLD && playerName.value !== ""
-        ? parsedBody.top_10
-        : parsedBody;
-
-    renderLeaderboardTable(leaderboard);
   }
 
   function maybeShowPostGameUi() {

--- a/js/puzzle-calendar.js
+++ b/js/puzzle-calendar.js
@@ -7,19 +7,12 @@ function startOfLocalDayMs(d) {
 /** Local calendar day 0 → `puzzles[0]`. Month is 0-based. */
 const PUZZLE_ROTATION_EPOCH = new Date(2026, 3, 26);
 
-const LEGACY_LEADERBOARD_EPOCH = new Date(2023, 4, 20);
-
 export function puzzleDayIndexAt(now, epochDate) {
   return Math.floor((startOfLocalDayMs(now) - startOfLocalDayMs(epochDate)) / DAY_MS);
 }
 
 export function calculatePuzzleDayIndex() {
   return puzzleDayIndexAt(new Date(), PUZZLE_ROTATION_EPOCH);
-}
-
-export function calculateDiffDays() {
-  const now = new Date();
-  return Math.ceil(Math.abs(now - LEGACY_LEADERBOARD_EPOCH) / DAY_MS);
 }
 
 export function puzzleListIndex(puzzleCount) {

--- a/js/word-drag.js
+++ b/js/word-drag.js
@@ -441,6 +441,7 @@ export function createWordDragHandlers(ctx, host) {
         });
       }
       const tilesToReplace = Array.from(w().selectedButtonSet);
+      host.recordLeaderboardScoreTurn?.(cw, tilesToReplace.length);
       host.addToScore(wordScore);
       const paceOrderResult = host.recordPerfectHuntOrderPace(cw);
       host.commitPerfectHuntWordIfListed(cw);

--- a/tests/puzzle-calendar.test.js
+++ b/tests/puzzle-calendar.test.js
@@ -1,15 +1,15 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
-  calculateDiffDays,
+  calculatePuzzleDayIndex,
   puzzleDayIndexAt,
   puzzleListIndex,
 } from "../js/puzzle-calendar.js";
 
-test("calculateDiffDays returns positive integer", () => {
-  const d = calculateDiffDays();
+test("calculatePuzzleDayIndex returns non-negative integer", () => {
+  const d = calculatePuzzleDayIndex();
   assert.equal(Number.isInteger(d), true);
-  assert.ok(d > 0);
+  assert.ok(d >= 0);
 });
 
 test("puzzleDayIndexAt: epoch day and day after", () => {


### PR DESCRIPTION
- Use calculatePuzzleDayIndex for URL and share text; drop legacy calculateDiffDays
- POST player/score/trophy only; normalize API rows [player, score, trophy] for UI
- Parse plain JSON or API Gateway body wrapper; consolidate fetch helpers
- Config: LEADERBOARD_API_BASE, demo off, LEADERBOARD_SUBMIT_SCORE_VALIDATION flag
- Record scoreValidation turns when flag on; README and puzzle-calendar tests updated