### PR TITLE
Leaderboard: align with Flask GET/POST payloads; commit detection; trim helpers

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -224,6 +224,7 @@ export function initGame(ctx) {
   /** @type {Array<[string, number, number|string, string]> | null} */
   let demoLeaderboardRows = null;
   let demoLeaderboardSubmitUsed = false;
+  let liveLeaderboardSubmitUsed = false;
   let copyScoreLineUsed = false;
   let deferRetryUntilCopyScoreLineVisible = false;
   let tilePaletteTransitionTimer = null;
@@ -929,6 +930,10 @@ export function initGame(ctx) {
     setDemoSubmitUsed: (v) => {
       demoLeaderboardSubmitUsed = v;
     },
+    getLiveLeaderboardSubmitUsed: () => liveLeaderboardSubmitUsed,
+    setLiveLeaderboardSubmitUsed: (v) => {
+      liveLeaderboardSubmitUsed = v;
+    },
     getPlayerPosition: () => playerPosition,
     setPlayerPosition: (v) => {
       playerPosition = v;
@@ -1020,6 +1025,7 @@ export function initGame(ctx) {
     }
     lbCtl.hidePostgameLeaderboardOverlay();
     demoLeaderboardSubmitUsed = false;
+    liveLeaderboardSubmitUsed = false;
     if (endgameTileStartTimer !== null) {
       window.clearTimeout(endgameTileStartTimer);
       endgameTileStartTimer = null;
@@ -1196,6 +1202,7 @@ export function initGame(ctx) {
     postgameSequenceStarted = false;
     demoLeaderboardRows = null;
     demoLeaderboardSubmitUsed = false;
+    liveLeaderboardSubmitUsed = false;
     if (!skipLeaderboardOverlayTeardown) {
       lbCtl.hidePostgameLeaderboardOverlay();
     }

--- a/js/leaderboard-ui.js
+++ b/js/leaderboard-ui.js
@@ -58,25 +58,39 @@ function parsedFetchPayload(raw) {
   return b ?? {};
 }
 
+function top10RowsFromPayload(payload) {
+  if (payload == null) return [];
+  if (Array.isArray(payload)) return payload;
+  if (typeof payload === "object" && Array.isArray(payload.top_10))
+    return payload.top_10;
+  return [];
+}
+
+const LEADERBOARD_POST_COMMIT_MARKERS = Object.freeze([
+  "record inserted successfully",
+  "this record already exists",
+]);
+
+function leaderboardPostMessageIndicatesCommit(payload) {
+  const m = String(payload?.message ?? "").toLowerCase();
+  return LEADERBOARD_POST_COMMIT_MARKERS.some((s) => m.includes(s));
+}
+
 function leaderboardRowsFromResponse(response, payload, didSubmit) {
   if (!response.ok) {
-    if (
-      didSubmit &&
-      payload &&
-      typeof payload === "object" &&
-      Array.isArray(payload.top_10)
-    ) {
-      return payload.top_10;
+    if (didSubmit) {
+      const fromBody = top10RowsFromPayload(payload);
+      if (
+        fromBody.length > 0 ||
+        (payload && typeof payload === "object" && "top_10" in payload)
+      ) {
+        return fromBody;
+      }
     }
     console.error("Leaderboard request failed", response.status, payload);
     return [];
   }
-  if (didSubmit) {
-    return payload && typeof payload === "object" && Array.isArray(payload.top_10)
-      ? payload.top_10
-      : [];
-  }
-  return Array.isArray(payload) ? payload : [];
+  return top10RowsFromPayload(payload);
 }
 
 function leaderboardNumericScore(row) {
@@ -221,14 +235,9 @@ export function createLeaderboardController(rt) {
         rt.getScore()
       );
     } else {
-      const playerHasScore = Number(rt.getScore()) > 0;
-      qualifies = playerHasScore;
-      if (qualifies && rows && rows.length >= 10) {
-        const tenthNum = leaderboardNumericScore(rows[9]);
-        if (tenthNum != null && tenthNum > 0) {
-          qualifies = rt.getScore() > tenthNum;
-        }
-      }
+      qualifies =
+        demoRunQualifiesForLeaderboard(rows, rt.getScore()) &&
+        !rt.getLiveLeaderboardSubmitUsed();
     }
 
     if (LEADERBOARD_USE_DEMO_DATA) {
@@ -575,8 +584,9 @@ export function createLeaderboardController(rt) {
       const payload = parsedFetchPayload(raw);
       const leaderboard = leaderboardRowsFromResponse(response, payload, willSubmit);
 
-      if (willSubmit && response.ok) {
+      if (willSubmit && response.ok && leaderboardPostMessageIndicatesCommit(payload)) {
         rt.playSound("submit", rt.getIsMuted());
+        rt.setLiveLeaderboardSubmitUsed(true);
       }
 
       renderLeaderboardTable(leaderboard);


### PR DESCRIPTION
- GET: root JSON array; POST: read top_10; unwrap API Gateway body when present.
- Only treat POST as submitted after message matches known success/duplicate markers.
- liveLeaderboardSubmitUsed wired from game host; reset on end/start game.
- Remove verbose comments; centralize POST message markers in a frozen list.