### PR TITLE
Leaderboard: live preview rules, modular JS, dev and tests

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -46,7 +46,8 @@ export const SHIFT_TAP_MAX_TRAVEL_PX = 20;
 export const SHIFT_TAP_MAX_PRESS_MS = 500;
 export const SHIFT_DOUBLE_END_GAME_MAX_GAP_MS_TOUCH = 325;
 export const SHIFT_DOUBLE_END_GAME_MAX_GAP_MS_MOUSE = 550;
-export const SCORE_SUBMIT_THRESHOLD = 50;
+/** Live leaderboard: score must be **greater than** this to submit and to show the preview row (`0` => score > 0). */
+export const SCORE_SUBMIT_THRESHOLD = 0;
 export const START_TOUCHPAD_FADE_MS = 420;
 export const TILE_PALETTE_MS = 420;
 /** Endgame only: active → inactive tile color transition (`tilePaletteToInactive`). */
@@ -55,10 +56,27 @@ export const TILE_PALETTE_TRANSITION_SETTLE_MS = 120;
 export const CURRENT_WORD_FADE_MS = 220;
 export const CURRENT_WORD_MESSAGE_EXTRA_MS = 500;
 export const CURRENT_WORD_MESSAGE_ON_MS = 1100 + CURRENT_WORD_MESSAGE_EXTRA_MS;
+/**
+ * Leaderboard: demo mode (`LEADERBOARD_USE_DEMO_DATA`) skips the API and uses the demo submit UI.
+ * Live base is `LEADERBOARD_PRODUCTION_API_BASE`; on localhost, `LEADERBOARD_API_BASE` points at the CORS proxy.
+ * Tests: `npm test` / `npm run test:leaderboard`. Local API without prod: `npm run dev:leaderboard`.
+ */
 export const LEADERBOARD_USE_DEMO_DATA = false;
-/** Trailing slash required; requests are `${LEADERBOARD_API_BASE}{puzzleId}`. */
-export const LEADERBOARD_API_BASE =
+export const LEADERBOARD_PRODUCTION_API_BASE =
   "https://johnriley81.pythonanywhere.com/leaderboard/";
+/** `${LEADERBOARD_API_BASE}{puzzleId}` — trailing slash required. */
+function resolveLeaderboardApiBase() {
+  if (typeof location === "undefined") {
+    return LEADERBOARD_PRODUCTION_API_BASE;
+  }
+  const h = location.hostname;
+  if (h === "localhost" || h === "127.0.0.1") {
+    return "http://127.0.0.1:8765/leaderboard/";
+  }
+  return LEADERBOARD_PRODUCTION_API_BASE;
+}
+
+export const LEADERBOARD_API_BASE = resolveLeaderboardApiBase();
 /** When true, POST includes `scoreValidation` (server `WORDHUNTER_VALIDATE_SCORE`). */
 export const LEADERBOARD_SUBMIT_SCORE_VALIDATION = false;
 /** Only when `LEADERBOARD_USE_DEMO_DATA`: empty GET-style board, optional inject rows for UI tests. */

--- a/js/game.js
+++ b/js/game.js
@@ -223,6 +223,7 @@ export function initGame(ctx) {
   let leaderboardFadeOutTimer = null;
   /** @type {Array<[string, number, number|string, string]> | null} */
   let demoLeaderboardRows = null;
+  let liveLeaderboardPreviewRows = null;
   let demoLeaderboardSubmitUsed = false;
   let liveLeaderboardSubmitUsed = false;
   let copyScoreLineUsed = false;
@@ -354,13 +355,14 @@ export function initGame(ctx) {
     });
   }
   leaderboardTable.addEventListener("click", (e) => {
-    if (!LEADERBOARD_USE_DEMO_DATA || demoLeaderboardSubmitUsed) return;
     if (!(e.target instanceof Element)) return;
-    const td = e.target.closest("td[data-demo-self-name]");
+    const td = e.target.closest("td[data-inline-self-name]");
     if (!td || !leaderboardTable.contains(td)) return;
+    if (LEADERBOARD_USE_DEMO_DATA && demoLeaderboardSubmitUsed) return;
+    if (!LEADERBOARD_USE_DEMO_DATA && liveLeaderboardSubmitUsed) return;
     if (td.querySelector(".leaderboard-inline-name-input")) return;
     e.preventDefault();
-    lbCtl.openDemoLeaderboardInlineNameEdit(td);
+    lbCtl.openLeaderboardInlineNameEdit(td);
   });
   updateCurrentWord();
   currentWordElement.textContent = PRE_START_WORDMARK;
@@ -934,6 +936,10 @@ export function initGame(ctx) {
     setLiveLeaderboardSubmitUsed: (v) => {
       liveLeaderboardSubmitUsed = v;
     },
+    getLiveLeaderboardPreviewRows: () => liveLeaderboardPreviewRows,
+    setLiveLeaderboardPreviewRows: (v) => {
+      liveLeaderboardPreviewRows = v;
+    },
     getPlayerPosition: () => playerPosition,
     setPlayerPosition: (v) => {
       playerPosition = v;
@@ -1026,6 +1032,7 @@ export function initGame(ctx) {
     lbCtl.hidePostgameLeaderboardOverlay();
     demoLeaderboardSubmitUsed = false;
     liveLeaderboardSubmitUsed = false;
+    liveLeaderboardPreviewRows = null;
     if (endgameTileStartTimer !== null) {
       window.clearTimeout(endgameTileStartTimer);
       endgameTileStartTimer = null;
@@ -1201,6 +1208,7 @@ export function initGame(ctx) {
     }
     postgameSequenceStarted = false;
     demoLeaderboardRows = null;
+    liveLeaderboardPreviewRows = null;
     demoLeaderboardSubmitUsed = false;
     liveLeaderboardSubmitUsed = false;
     if (!skipLeaderboardOverlayTeardown) {

--- a/js/leaderboard-api.js
+++ b/js/leaderboard-api.js
@@ -1,0 +1,165 @@
+export function normalizeLeaderboardRow(row) {
+  if (!Array.isArray(row)) return ["", 0, "", ""];
+  if (row.length >= 4) {
+    return [
+      String(row[0] ?? ""),
+      Number(row[1]) === 1 ? 1 : 0,
+      row[2],
+      String(row[3] ?? ""),
+    ];
+  }
+  if (row.length >= 3) {
+    return [String(row[0] ?? ""), 0, row[1], String(row[2] ?? "")];
+  }
+  return ["", 0, "", ""];
+}
+
+export function normalizeLeaderboardRows(raw) {
+  if (!Array.isArray(raw)) return [];
+  return raw.map(normalizeLeaderboardRow);
+}
+
+function shouldLogLeaderboardDebug() {
+  if (
+    typeof process !== "undefined" &&
+    process.env?.WORDHUNTER_DEBUG_LEADERBOARD === "1"
+  ) {
+    return true;
+  }
+  try {
+    if (typeof globalThis.localStorage === "undefined") return false;
+    return globalThis.localStorage.getItem("WORDHUNTER_DEBUG_LEADERBOARD") === "1";
+  } catch {
+    return false;
+  }
+}
+
+/** Logs only when `WORDHUNTER_DEBUG_LEADERBOARD=1` (Node) or `localStorage` same key (browser). */
+export function leaderboardDebugWarn(...args) {
+  if (!shouldLogLeaderboardDebug()) return;
+  const norm = args.map((a) => (a instanceof Error ? a.message : a));
+  console.warn("[leaderboard]", ...norm);
+}
+
+/** Pads with empty placeholder rows so the live top-10 table always shows 10 slots (after submit or GET). */
+export function padNormalizedLeaderboardToTop10(rows) {
+  const out = normalizeLeaderboardRows(Array.isArray(rows) ? rows : []).slice(0, 10);
+  while (out.length < 10) {
+    out.push(["", 0, "", ""]);
+  }
+  return out;
+}
+
+export function parsedFetchPayload(raw) {
+  if (raw == null || typeof raw !== "object" || !("body" in raw)) return raw;
+  const b = raw.body;
+  if (typeof b === "string") {
+    try {
+      return JSON.parse(b);
+    } catch {
+      return {};
+    }
+  }
+  return b ?? {};
+}
+
+/**
+ * Leaderboard rows from a GET or successful POST body. Same wire format:
+ * - a JSON array of [player, score, trophy] tuples (typical GET), or
+ * - an object with `top_10`, `top10`, or `leaderboard` array (often POST with `message`).
+ */
+export function top10RowsFromPayload(payload) {
+  if (payload == null) return [];
+  if (Array.isArray(payload)) return payload;
+  if (typeof payload === "object") {
+    if (Array.isArray(payload.top_10)) return payload.top_10;
+    if (Array.isArray(payload.top10)) return payload.top10;
+    if (Array.isArray(payload.leaderboard)) return payload.leaderboard;
+  }
+  return [];
+}
+
+const LEADERBOARD_POST_COMMIT_MARKERS = Object.freeze([
+  "record inserted successfully",
+  "this record already exists",
+]);
+
+function leaderboardPayloadIndicatesSoftReject(payload) {
+  if (payload == null || typeof payload !== "object" || Array.isArray(payload))
+    return false;
+  const message = String(payload.message ?? "")
+    .trim()
+    .toLowerCase();
+  if (message.includes("profanity")) return true;
+  if (
+    message.includes("reject") &&
+    !LEADERBOARD_POST_COMMIT_MARKERS.some((s) => message.includes(s))
+  ) {
+    return true;
+  }
+  return false;
+}
+
+function leaderboardPayloadIndicatesHardErrorField(payload) {
+  if (payload == null || typeof payload !== "object" || Array.isArray(payload))
+    return false;
+  const err = payload.error ?? payload.errors;
+  if (err == null || err === false) return false;
+  if (typeof err === "string") return err.trim().length > 0;
+  if (typeof err === "object" && Object.keys(err).length > 0) return true;
+  return Boolean(err);
+}
+
+export function leaderboardPostMessageIndicatesCommit(payload) {
+  const m = String(payload?.message ?? "").toLowerCase();
+  return LEADERBOARD_POST_COMMIT_MARKERS.some((s) => m.includes(s));
+}
+
+/**
+ * Whether a successful score POST should lock live submit (no second post this run).
+ */
+export function leaderboardPostTreatAsCommitted(ok, payload, didSubmit) {
+  if (!didSubmit || !ok) return false;
+  if (payload == null) return true;
+  if (Array.isArray(payload)) {
+    return true;
+  }
+  if (typeof payload !== "object") return true;
+  if (leaderboardPayloadIndicatesHardErrorField(payload)) return false;
+  if (leaderboardPayloadIndicatesSoftReject(payload)) return false;
+  const message = String(payload.message ?? "").trim();
+  const lower = message.toLowerCase();
+  if (leaderboardPostMessageIndicatesCommit(payload)) return true;
+  if (top10RowsFromPayload(payload).length > 0) return true;
+  if (!message) return true;
+  if (
+    lower.includes("success") ||
+    lower.includes("saved") ||
+    lower.includes("recorded") ||
+    lower.includes("accepted") ||
+    lower.includes("added") ||
+    lower.includes("updated") ||
+    lower.includes("thank")
+  ) {
+    return true;
+  }
+  return false;
+}
+
+export function leaderboardRowsFromResponse(response, payload, didSubmit) {
+  if (!response.ok) {
+    if (didSubmit) {
+      const fromBody = top10RowsFromPayload(payload);
+      const hasBoardKey =
+        payload &&
+        typeof payload === "object" &&
+        ("top_10" in payload || "top10" in payload || "leaderboard" in payload);
+      if (fromBody.length > 0 || hasBoardKey) {
+        return fromBody;
+      }
+    }
+    leaderboardDebugWarn("Leaderboard request failed", response.status, payload);
+    return [];
+  }
+  return top10RowsFromPayload(payload);
+}

--- a/js/leaderboard-lifecycle.js
+++ b/js/leaderboard-lifecycle.js
@@ -1,4 +1,71 @@
-import { DEMO_LEADERBOARD_NAME_MAX } from "./config.js";
+import { DEMO_LEADERBOARD_NAME_MAX, SCORE_SUBMIT_THRESHOLD } from "./config.js";
+import { leaderboardNumericScore } from "./leaderboard-ui-helpers.js";
+
+export function sanitizeDemoLeaderboardName(raw) {
+  return String(raw || "")
+    .replace(/[^a-zA-Z]/g, "")
+    .toUpperCase()
+    .slice(0, DEMO_LEADERBOARD_NAME_MAX);
+}
+
+/** Empty #player-name matches display YOU. */
+export function leaderboardPreviewNameKey(raw) {
+  const t = String(raw ?? "").trim();
+  if (!t) return "YOU";
+  return sanitizeDemoLeaderboardName(t) || t;
+}
+
+/** Preview row index for inline edit: same run (score + trophy) and same name key as the field. */
+export function leaderboardLiveSelfRowIndex(
+  rows,
+  playerNameValue,
+  runScore,
+  longestWord
+) {
+  if (!rows?.length) return -1;
+  const trophy = String(longestWord ?? "").trim();
+  const want = Number(runScore);
+  const previewKey = leaderboardPreviewNameKey(playerNameValue);
+  return rows.findIndex(
+    (r) =>
+      leaderboardNumericScore(r) === want &&
+      String(r[3] || "").trim() === trophy &&
+      leaderboardPreviewNameKey(r[0]) === previewKey
+  );
+}
+
+/** POST name from preview rows when #player-name is empty. */
+export function leaderboardLiveSubmitNameFallbackRaw(
+  rows,
+  playerNameValue,
+  runScore,
+  longestWord
+) {
+  if (!rows?.length) return "";
+  const trophy = String(longestWord ?? "").trim();
+  const want = Number(runScore);
+  const matches = [];
+  for (const r of rows) {
+    if (leaderboardNumericScore(r) === want && String(r[3] || "").trim() === trophy) {
+      matches.push(r);
+    }
+  }
+  if (!matches.length) return "";
+  const previewKey = leaderboardPreviewNameKey(playerNameValue);
+  const keyed = matches.find((r) => leaderboardPreviewNameKey(r[0]) === previewKey);
+  if (keyed) {
+    const raw = String(keyed[0] ?? "").trim();
+    return raw || "YOU";
+  }
+  if (matches.length === 1) {
+    const raw = String(matches[0][0] ?? "").trim();
+    if (raw) return raw;
+    const n = leaderboardNumericScore(matches[0]);
+    if (n != null && Number.isFinite(n) && n > 0) return "YOU";
+    return "";
+  }
+  return "";
+}
 
 export function buildDemoLeaderboardRows() {
   const rows = [];
@@ -29,32 +96,67 @@ export function demoRunQualifiesForLeaderboard(baseRows, runScore) {
   return s > tenthNum;
 }
 
+export function applyLiveLeaderboardPreviewMerge(
+  normalizedApiRows,
+  trimmedPlayerName,
+  runScore,
+  longestWord,
+  { useDemoData, liveSubmitUsed }
+) {
+  if (useDemoData || liveSubmitUsed) return normalizedApiRows;
+  const run = Number(runScore);
+  if (
+    !(Number.isFinite(run) && run > SCORE_SUBMIT_THRESHOLD) ||
+    !demoRunQualifiesForLeaderboard(normalizedApiRows, run)
+  ) {
+    return normalizedApiRows;
+  }
+  return mergeDemoRunIntoTop10(
+    normalizedApiRows,
+    trimmedPlayerName || "YOU",
+    run,
+    String(longestWord || "").trim()
+  );
+}
+
 export function mergeDemoRunIntoTop10(baseRows, name, runScore, trophy) {
-  const filled = baseRows.map((r) => {
+  const filled = baseRows.map((r, idx) => {
     return [
       String(r[0] || ""),
       Number(r[1]) === 1 ? 1 : 0,
       r[2] === "" || r[2] === null || r[2] === undefined ? "" : Number(r[2]),
       String(r[3] || ""),
+      idx,
     ];
   });
-  /** @type {[string, number, number, string]} */
-  const newRow = [name, 0, runScore, String(trophy || "")];
   const dataRows = filled.filter(
     (r) => (r[0] && String(r[0]).trim()) || (r[2] !== "" && !Number.isNaN(Number(r[2])))
   );
-  dataRows.push(newRow);
-  dataRows.sort((a, b) => Number(b[2]) - Number(a[2]));
-  const next = dataRows.slice(0, 10);
+  const nameKey = sanitizeDemoLeaderboardName(name);
+  const trophyKey = String(trophy || "")
+    .trim()
+    .toUpperCase();
+  const scoreNum = Number(runScore);
+  const deduped = dataRows.filter((r) => {
+    const sameScore = Number(r[2]) === scoreNum;
+    const sameTrophy =
+      String(r[3] || "")
+        .trim()
+        .toUpperCase() === trophyKey;
+    const sameName = sanitizeDemoLeaderboardName(r[0]) === nameKey;
+    return !(sameScore && sameTrophy && sameName);
+  });
+  const maxOrder = deduped.length === 0 ? -1 : Math.max(...deduped.map((r) => r[4]));
+  const newRow = [name, 0, runScore, String(trophy || ""), maxOrder + 1];
+  deduped.push(newRow);
+  deduped.sort((a, b) => {
+    const byScore = Number(b[2]) - Number(a[2]);
+    if (byScore !== 0) return byScore;
+    return Number(a[4]) - Number(b[4]);
+  });
+  const next = deduped.slice(0, 10).map((r) => r.slice(0, 4));
   while (next.length < 10) {
     next.push(["", 0, "", ""]);
   }
   return next;
-}
-
-export function sanitizeDemoLeaderboardName(raw) {
-  return String(raw || "")
-    .replace(/[^a-zA-Z]/g, "")
-    .toUpperCase()
-    .slice(0, DEMO_LEADERBOARD_NAME_MAX);
 }

--- a/js/leaderboard-live-flow.js
+++ b/js/leaderboard-live-flow.js
@@ -1,0 +1,57 @@
+import {
+  parsedFetchPayload,
+  normalizeLeaderboardRows,
+  padNormalizedLeaderboardToTop10,
+  leaderboardRowsFromResponse,
+  leaderboardPostTreatAsCommitted,
+} from "./leaderboard-api.js";
+import { applyLiveLeaderboardPreviewMerge } from "./leaderboard-lifecycle.js";
+
+export function leaderboardCanPostLive(clicked, score, nameTrim, scoreThreshold) {
+  return (
+    clicked && Number(score) > scoreThreshold && String(nameTrim || "").trim() !== ""
+  );
+}
+
+export function deriveLiveLeaderboardAfterFetch(network, input) {
+  const { ok, raw, status } = network;
+  const {
+    clicked,
+    score,
+    nameTrim,
+    longestWord,
+    scoreThreshold,
+    useDemoData,
+    liveSubmitUsed,
+  } = input;
+
+  const trimmedName = String(nameTrim || "").trim();
+  const canPost = leaderboardCanPostLive(clicked, score, trimmedName, scoreThreshold);
+  const payload = parsedFetchPayload(raw);
+  const response = { ok, status: status ?? (ok ? 200 : 400) };
+
+  const fromNetwork = leaderboardRowsFromResponse(response, payload, canPost);
+  let tableRows = Array.isArray(fromNetwork) ? fromNetwork : [];
+
+  const runPreviewMerge = (norm) =>
+    applyLiveLeaderboardPreviewMerge(norm, trimmedName, score, longestWord, {
+      useDemoData,
+      liveSubmitUsed,
+    });
+
+  if (!useDemoData && !canPost && !liveSubmitUsed) {
+    tableRows = runPreviewMerge(normalizeLeaderboardRows(tableRows));
+  }
+
+  if (!useDemoData && !liveSubmitUsed && tableRows.length === 0 && !(canPost && ok)) {
+    tableRows = runPreviewMerge(normalizeLeaderboardRows([]));
+  }
+
+  const committed = leaderboardPostTreatAsCommitted(ok, payload, canPost);
+
+  if (!useDemoData && tableRows.length > 0) {
+    tableRows = padNormalizedLeaderboardToTop10(tableRows);
+  }
+
+  return { tableRows, committed, canPost };
+}

--- a/js/leaderboard-ui-demo-merge.js
+++ b/js/leaderboard-ui-demo-merge.js
@@ -1,0 +1,53 @@
+import {
+  LEADERBOARD_USE_DEMO_DATA,
+  LEADERBOARD_DEMO_EMPTY_BOARD,
+  LEADERBOARD_DEMO_INJECT_PERFECT_HUNT_ROW,
+  LEADERBOARD_DEMO_INJECT_OVER_PERFECT_HUNT_ROW,
+  LEADERBOARD_DEMO_OVER_PERFECT_SCORE_EXTRA,
+} from "./config.js";
+import { mergeDemoRunIntoTop10 } from "./leaderboard-lifecycle.js";
+import { leaderboardNumericScore } from "./leaderboard-ui-helpers.js";
+
+/** Demo-only row injection for perfect / over-perfect hunt preview (see config flags). */
+export function mergeDemoLeaderboardPreviewRows(leaderboard, perfectTargetSum) {
+  if (!LEADERBOARD_USE_DEMO_DATA) return leaderboard;
+  if (LEADERBOARD_DEMO_EMPTY_BOARD) {
+    return leaderboard;
+  }
+  const target = perfectTargetSum;
+  if (target == null || !Number.isFinite(target)) return leaderboard;
+  let rows = leaderboard;
+  if (LEADERBOARD_DEMO_INJECT_PERFECT_HUNT_ROW) {
+    const hasPerfect = rows.some(
+      (r) =>
+        String(r[0] || "")
+          .trim()
+          .toUpperCase() === "PERFECT" &&
+        Number(r[2]) === target &&
+        String(r[3] || "")
+          .trim()
+          .toUpperCase() === "PERFECT HUNT"
+    );
+    if (!hasPerfect) {
+      rows = mergeDemoRunIntoTop10(rows, "PERFECT", target, "PERFECT HUNT");
+    }
+  }
+  if (LEADERBOARD_DEMO_INJECT_OVER_PERFECT_HUNT_ROW) {
+    const extra = Math.max(1, Number(LEADERBOARD_DEMO_OVER_PERFECT_SCORE_EXTRA) || 1);
+    const overScore = target + extra;
+    const hasOver = rows.some((r) => {
+      const n = leaderboardNumericScore(r);
+      return (
+        n != null &&
+        n > target &&
+        String(r[0] || "")
+          .trim()
+          .toUpperCase() === "TOOHIGH"
+      );
+    });
+    if (!hasOver) {
+      rows = mergeDemoRunIntoTop10(rows, "TOOHIGH", overScore, "HOW??");
+    }
+  }
+  return rows;
+}

--- a/js/leaderboard-ui-helpers.js
+++ b/js/leaderboard-ui-helpers.js
@@ -1,0 +1,51 @@
+/** Shared leaderboard table utilities (no `rt` / fetch). */
+
+export function leaderboardNumericScore(row) {
+  const raw = row[2];
+  if (raw === "" || raw === null || raw === undefined || Number.isNaN(Number(raw))) {
+    return null;
+  }
+  return Number(raw);
+}
+
+export function submittingSubPerfectFromRun(perfectTarget, runScoreNum) {
+  return (
+    perfectTarget != null &&
+    Number.isFinite(perfectTarget) &&
+    Number.isFinite(runScoreNum) &&
+    runScoreNum < perfectTarget
+  );
+}
+
+export function rowPerfectOverFlags(perfectTarget, row) {
+  const scoreNum = leaderboardNumericScore(row);
+  const hasScore = scoreNum !== null;
+  return {
+    isPerfectHuntScore: perfectTarget != null && hasScore && scoreNum === perfectTarget,
+    isAbovePerfectHunt: perfectTarget != null && hasScore && scoreNum > perfectTarget,
+  };
+}
+
+export function setLeaderboardCellFlash(td, text, kind) {
+  const cls =
+    kind === "perfect"
+      ? "leaderboard-perfect-hunt-flash"
+      : kind === "over"
+        ? "leaderboard-over-perfect-glow"
+        : null;
+  if (cls) {
+    const span = document.createElement("span");
+    span.className = cls;
+    span.textContent = text;
+    td.appendChild(span);
+    return;
+  }
+  td.textContent = text;
+}
+
+export function syncLeaderboardNameCellSubPerfect(td, subPerfect) {
+  td.classList.toggle(
+    "leaderboard-name-cell--you-pseudo-select--sub-perfect",
+    subPerfect
+  );
+}

--- a/js/leaderboard-ui-submit-visibility.js
+++ b/js/leaderboard-ui-submit-visibility.js
@@ -1,0 +1,74 @@
+/**
+ * Live submit / demo-add visibility (score threshold vs board eligibility).
+ */
+export function applyLeaderboardSubmitButtonVisibility({
+  leaderboardUseDemoData,
+  refs,
+  qualifiesForBoardSlot,
+  score,
+  scoreSubmitThreshold,
+  liveSubmitUsed,
+  demoSubmitUsed,
+}) {
+  const { leaderboardButton, leaderboardDemoAdd } = refs;
+
+  if (leaderboardUseDemoData) {
+    leaderboardButton.classList.add("hiddenDisplay");
+    leaderboardButton.classList.add("leaderboard-action--concealed");
+    if (leaderboardDemoAdd) {
+      if (demoSubmitUsed) {
+        leaderboardDemoAdd.classList.remove("leaderboard-demo-add--eligible");
+        leaderboardDemoAdd.classList.remove("leaderboard-demo-add--spent");
+        leaderboardDemoAdd.disabled = true;
+        leaderboardDemoAdd.classList.add("hiddenDisplay");
+        leaderboardDemoAdd.classList.add("leaderboard-action--concealed");
+        return;
+      }
+
+      leaderboardDemoAdd.classList.remove("hiddenDisplay");
+      leaderboardDemoAdd.classList.remove("leaderboard-action--concealed");
+      leaderboardDemoAdd.disabled = false;
+      leaderboardDemoAdd.classList.remove("leaderboard-demo-add--spent");
+      leaderboardDemoAdd.classList.remove("leaderboard-demo-add--eligible");
+
+      if (qualifiesForBoardSlot) {
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => {
+            leaderboardDemoAdd.classList.add("leaderboard-demo-add--eligible");
+          });
+        });
+      }
+    }
+    return;
+  }
+
+  if (leaderboardDemoAdd) {
+    leaderboardDemoAdd.classList.remove("leaderboard-demo-add--eligible");
+    leaderboardDemoAdd.classList.remove("leaderboard-demo-add--spent");
+    leaderboardDemoAdd.disabled = false;
+    leaderboardDemoAdd.classList.add("hiddenDisplay");
+  }
+
+  const runScore = Number(score);
+  const meetsSubmitScoreMinimum =
+    Number.isFinite(runScore) && runScore > scoreSubmitThreshold;
+  if (!meetsSubmitScoreMinimum) {
+    leaderboardButton.classList.add("hiddenDisplay");
+    leaderboardButton.classList.add("leaderboard-action--concealed");
+    leaderboardButton.disabled = true;
+    leaderboardButton.style.removeProperty("background-color");
+    return;
+  }
+
+  leaderboardButton.classList.remove("hiddenDisplay");
+  leaderboardButton.classList.toggle(
+    "leaderboard-action--concealed",
+    !qualifiesForBoardSlot
+  );
+  leaderboardButton.disabled = liveSubmitUsed;
+  if (liveSubmitUsed) {
+    leaderboardButton.style.backgroundColor = "rgba(95, 95, 95, 0.92)";
+  } else {
+    leaderboardButton.style.removeProperty("background-color");
+  }
+}

--- a/js/leaderboard-ui.js
+++ b/js/leaderboard-ui.js
@@ -2,9 +2,6 @@ import {
   LEADERBOARD_USE_DEMO_DATA,
   LEADERBOARD_DEMO_EMPTY_BOARD,
   LEADERBOARD_SUBMIT_SCORE_VALIDATION,
-  LEADERBOARD_DEMO_INJECT_PERFECT_HUNT_ROW,
-  LEADERBOARD_DEMO_INJECT_OVER_PERFECT_HUNT_ROW,
-  LEADERBOARD_DEMO_OVER_PERFECT_SCORE_EXTRA,
   DEMO_LEADERBOARD_NAME_MAX,
   LEADERBOARD_OVERLAY_FADE_OUT_TOTAL_MS,
   LEADERBOARD_COPY_SCORE_AFTER_OVERLAY_FADE_MS as DEFAULT_COPY_SCORE_AFTER_OVERLAY_MS,
@@ -16,155 +13,71 @@ import {
   redTextColorLeaderboard,
 } from "./config.js";
 import {
+  normalizeLeaderboardRows,
+  leaderboardDebugWarn,
+  padNormalizedLeaderboardToTop10,
+} from "./leaderboard-api.js";
+import {
   buildDemoLeaderboardRows,
   demoRunQualifiesForLeaderboard,
   mergeDemoRunIntoTop10,
+  leaderboardPreviewNameKey,
+  leaderboardLiveSelfRowIndex,
+  leaderboardLiveSubmitNameFallbackRaw,
   sanitizeDemoLeaderboardName,
 } from "./leaderboard-lifecycle.js";
+import {
+  leaderboardCanPostLive,
+  deriveLiveLeaderboardAfterFetch,
+} from "./leaderboard-live-flow.js";
+import { mergeDemoLeaderboardPreviewRows } from "./leaderboard-ui-demo-merge.js";
+import { applyLeaderboardSubmitButtonVisibility } from "./leaderboard-ui-submit-visibility.js";
+import {
+  leaderboardNumericScore,
+  submittingSubPerfectFromRun,
+  rowPerfectOverFlags,
+  setLeaderboardCellFlash,
+  syncLeaderboardNameCellSubPerfect,
+} from "./leaderboard-ui-helpers.js";
 import { clearWordLineTimers, fadeInCurrentWordLine } from "./ui-word-line.js";
 import { unlockGameAudio } from "./audio.js";
 
-function normalizeLeaderboardRow(row) {
-  if (!Array.isArray(row)) return ["", 0, "", ""];
-  if (row.length >= 4) {
-    return [
-      String(row[0] ?? ""),
-      Number(row[1]) === 1 ? 1 : 0,
-      row[2],
-      String(row[3] ?? ""),
-    ];
-  }
-  if (row.length >= 3) {
-    return [String(row[0] ?? ""), 0, row[1], String(row[2] ?? "")];
-  }
-  return ["", 0, "", ""];
-}
-
-function normalizeLeaderboardRows(raw) {
-  if (!Array.isArray(raw)) return [];
-  return raw.map(normalizeLeaderboardRow);
-}
-
-function parsedFetchPayload(raw) {
-  if (raw == null || typeof raw !== "object" || !("body" in raw)) return raw;
-  const b = raw.body;
-  if (typeof b === "string") {
-    try {
-      return JSON.parse(b);
-    } catch {
-      return {};
-    }
-  }
-  return b ?? {};
-}
-
-function top10RowsFromPayload(payload) {
-  if (payload == null) return [];
-  if (Array.isArray(payload)) return payload;
-  if (typeof payload === "object" && Array.isArray(payload.top_10))
-    return payload.top_10;
-  return [];
-}
-
-const LEADERBOARD_POST_COMMIT_MARKERS = Object.freeze([
-  "record inserted successfully",
-  "this record already exists",
-]);
-
-function leaderboardPostMessageIndicatesCommit(payload) {
-  const m = String(payload?.message ?? "").toLowerCase();
-  return LEADERBOARD_POST_COMMIT_MARKERS.some((s) => m.includes(s));
-}
-
-function leaderboardRowsFromResponse(response, payload, didSubmit) {
-  if (!response.ok) {
-    if (didSubmit) {
-      const fromBody = top10RowsFromPayload(payload);
-      if (
-        fromBody.length > 0 ||
-        (payload && typeof payload === "object" && "top_10" in payload)
-      ) {
-        return fromBody;
-      }
-    }
-    console.error("Leaderboard request failed", response.status, payload);
-    return [];
-  }
-  return top10RowsFromPayload(payload);
-}
-
-function leaderboardNumericScore(row) {
-  const raw = row[2];
-  if (raw === "" || raw === null || raw === undefined || Number.isNaN(Number(raw))) {
-    return null;
-  }
-  return Number(raw);
-}
-
-function submittingSubPerfectFromRun(perfectTarget, runScoreNum) {
-  return (
-    perfectTarget != null &&
-    Number.isFinite(perfectTarget) &&
-    Number.isFinite(runScoreNum) &&
-    runScoreNum < perfectTarget
-  );
-}
-
-function rowPerfectOverFlags(perfectTarget, row) {
-  const scoreNum = leaderboardNumericScore(row);
-  const hasScore = scoreNum !== null;
-  return {
-    isPerfectHuntScore: perfectTarget != null && hasScore && scoreNum === perfectTarget,
-    isAbovePerfectHunt: perfectTarget != null && hasScore && scoreNum > perfectTarget,
-  };
-}
-
-function setLeaderboardCellFlash(td, text, kind) {
-  const cls =
-    kind === "perfect"
-      ? "leaderboard-perfect-hunt-flash"
-      : kind === "over"
-        ? "leaderboard-over-perfect-glow"
-        : null;
-  if (cls) {
-    const span = document.createElement("span");
-    span.className = cls;
-    span.textContent = text;
-    td.appendChild(span);
-    return;
-  }
-  td.textContent = text;
+function trimLeaderboardSubmitName(raw) {
+  return String(sanitizeDemoLeaderboardName(raw) || String(raw ?? "").trim()).trim();
 }
 
 export function createLeaderboardController(rt) {
   const refs = () => rt.ctx.refs;
 
-  function isRunSubmittingSubPerfect() {
-    const cap = rt.getPerfectHuntTargetSum?.() ?? null;
-    const run = Number(rt.getScore());
-    return submittingSubPerfectFromRun(cap, run);
-  }
-
-  function syncDemoSelfPseudoSelectSubPerfect(td, subPerfect) {
-    td.classList.toggle(
-      "leaderboard-name-cell--you-pseudo-select--sub-perfect",
-      subPerfect
-    );
-  }
-
   function findDemoSelfRowIndex() {
     const rows = rt.getDemoRows();
     if (!LEADERBOARD_USE_DEMO_DATA || !rows) return -1;
     const trophy = String(rt.getLongestWord() || "").trim();
-    const want = rt.getScore();
+    const want = Number(rt.getScore());
     return rows.findIndex(
       (r) => leaderboardNumericScore(r) === want && String(r[3] || "").trim() === trophy
     );
   }
 
-  function openDemoLeaderboardInlineNameEdit(td) {
-    const rows = rt.getDemoRows();
-    const idx = findDemoSelfRowIndex();
+  function findLiveSelfRowIndex() {
+    return leaderboardLiveSelfRowIndex(
+      rt.getLiveLeaderboardPreviewRows?.(),
+      refs().playerName.value,
+      rt.getScore(),
+      rt.getLongestWord()
+    );
+  }
+
+  function openLeaderboardInlineNameEdit(td) {
+    let rows;
+    let idx;
+    if (LEADERBOARD_USE_DEMO_DATA) {
+      rows = rt.getDemoRows();
+      idx = findDemoSelfRowIndex();
+    } else {
+      rows = rt.getLiveLeaderboardPreviewRows?.();
+      idx = findLiveSelfRowIndex();
+    }
     if (idx < 0 || !rows) return;
     const nameVal = sanitizeDemoLeaderboardName(rows[idx][0]) || "YOU";
     const row = rows[idx];
@@ -180,10 +93,10 @@ export function createLeaderboardController(rt) {
     );
 
     td.textContent = "";
-    td.removeAttribute("data-demo-self-name");
+    td.removeAttribute("data-inline-self-name");
     td.classList.add("leaderboard-name-cell--editing-name");
     td.classList.add("leaderboard-name-cell--you-pseudo-select");
-    syncDemoSelfPseudoSelectSubPerfect(td, submittingSubPerfect);
+    syncLeaderboardNameCellSubPerfect(td, submittingSubPerfect);
 
     const input = document.createElement("input");
     input.type = "text";
@@ -212,6 +125,9 @@ export function createLeaderboardController(rt) {
       const v = sanitizeDemoLeaderboardName(input.value);
       input.value = v;
       rows[idx][0] = v;
+      if (!LEADERBOARD_USE_DEMO_DATA) {
+        refs().playerName.value = v;
+      }
     });
     input.addEventListener("keydown", (e) => {
       if (e.key === "Enter") {
@@ -222,105 +138,11 @@ export function createLeaderboardController(rt) {
     input.addEventListener("blur", () => {
       const v = sanitizeDemoLeaderboardName(input.value);
       rows[idx][0] = v || "YOU";
+      if (!LEADERBOARD_USE_DEMO_DATA) {
+        refs().playerName.value = v || "";
+      }
       renderLeaderboardTable(rows);
     });
-  }
-
-  function applyLeaderboardSubmitButtonVisibility(rows) {
-    const { leaderboardButton, leaderboardDemoAdd, playerName } = refs();
-    let qualifies;
-    if (LEADERBOARD_USE_DEMO_DATA) {
-      qualifies = demoRunQualifiesForLeaderboard(
-        LEADERBOARD_DEMO_EMPTY_BOARD ? [] : buildDemoLeaderboardRows(),
-        rt.getScore()
-      );
-    } else {
-      qualifies =
-        demoRunQualifiesForLeaderboard(rows, rt.getScore()) &&
-        !rt.getLiveLeaderboardSubmitUsed();
-    }
-
-    if (LEADERBOARD_USE_DEMO_DATA) {
-      leaderboardButton.classList.add("hiddenDisplay");
-      leaderboardButton.classList.add("leaderboard-action--concealed");
-      if (leaderboardDemoAdd) {
-        if (rt.getDemoSubmitUsed()) {
-          leaderboardDemoAdd.classList.remove("leaderboard-demo-add--eligible");
-          leaderboardDemoAdd.classList.remove("leaderboard-demo-add--spent");
-          leaderboardDemoAdd.disabled = true;
-          leaderboardDemoAdd.classList.add("hiddenDisplay");
-          leaderboardDemoAdd.classList.add("leaderboard-action--concealed");
-          return;
-        }
-
-        leaderboardDemoAdd.classList.remove("hiddenDisplay");
-        leaderboardDemoAdd.classList.remove("leaderboard-action--concealed");
-        leaderboardDemoAdd.disabled = false;
-        leaderboardDemoAdd.classList.remove("leaderboard-demo-add--spent");
-        leaderboardDemoAdd.classList.remove("leaderboard-demo-add--eligible");
-
-        if (qualifies) {
-          requestAnimationFrame(() => {
-            requestAnimationFrame(() => {
-              leaderboardDemoAdd.classList.add("leaderboard-demo-add--eligible");
-            });
-          });
-        }
-      }
-      return;
-    }
-
-    if (leaderboardDemoAdd) {
-      leaderboardDemoAdd.classList.remove("leaderboard-demo-add--eligible");
-      leaderboardDemoAdd.classList.remove("leaderboard-demo-add--spent");
-      leaderboardDemoAdd.disabled = false;
-      leaderboardDemoAdd.classList.add("hiddenDisplay");
-    }
-    leaderboardButton.classList.remove("hiddenDisplay");
-    leaderboardButton.classList.toggle("leaderboard-action--concealed", !qualifies);
-  }
-
-  function mergeDemoLeaderboardPreviewRows(leaderboard) {
-    if (!LEADERBOARD_USE_DEMO_DATA) return leaderboard;
-    if (LEADERBOARD_DEMO_EMPTY_BOARD) {
-      return leaderboard;
-    }
-    const target = rt.getPerfectHuntTargetSum?.() ?? null;
-    if (target == null || !Number.isFinite(target)) return leaderboard;
-    let rows = leaderboard;
-    if (LEADERBOARD_DEMO_INJECT_PERFECT_HUNT_ROW) {
-      const hasPerfect = rows.some(
-        (r) =>
-          String(r[0] || "")
-            .trim()
-            .toUpperCase() === "PERFECT" &&
-          Number(r[2]) === target &&
-          String(r[3] || "")
-            .trim()
-            .toUpperCase() === "PERFECT HUNT"
-      );
-      if (!hasPerfect) {
-        rows = mergeDemoRunIntoTop10(rows, "PERFECT", target, "PERFECT HUNT");
-      }
-    }
-    if (LEADERBOARD_DEMO_INJECT_OVER_PERFECT_HUNT_ROW) {
-      const extra = Math.max(1, Number(LEADERBOARD_DEMO_OVER_PERFECT_SCORE_EXTRA) || 1);
-      const overScore = target + extra;
-      const hasOver = rows.some((r) => {
-        const n = leaderboardNumericScore(r);
-        return (
-          n != null &&
-          n > target &&
-          String(r[0] || "")
-            .trim()
-            .toUpperCase() === "TOOHIGH"
-        );
-      });
-      if (!hasOver) {
-        rows = mergeDemoRunIntoTop10(rows, "TOOHIGH", overScore, "HOW??");
-      }
-    }
-    return rows;
   }
 
   function renderLeaderboardTable(leaderboard) {
@@ -330,9 +152,15 @@ export function createLeaderboardController(rt) {
     const thead = document.createElement("thead");
     const tbody = document.createElement("tbody");
 
-    const rows = mergeDemoLeaderboardPreviewRows(
-      normalizeLeaderboardRows(Array.isArray(leaderboard) ? leaderboard : [])
+    const perfectTargetForDemoMerge = rt.getPerfectHuntTargetSum?.() ?? null;
+    let rows = mergeDemoLeaderboardPreviewRows(
+      normalizeLeaderboardRows(Array.isArray(leaderboard) ? leaderboard : []),
+      perfectTargetForDemoMerge
     );
+    if (!LEADERBOARD_USE_DEMO_DATA) {
+      rows = padNormalizedLeaderboardToTop10(rows);
+      rt.setLiveLeaderboardPreviewRows(rows.map((r) => r.slice()));
+    }
     const headerRow = document.createElement("tr");
     ["", "👤", "🏹", "🏆"].forEach((headerText) => {
       const th = document.createElement("th");
@@ -348,6 +176,10 @@ export function createLeaderboardController(rt) {
       runScoreNum
     );
     const typedPlayerName = String(playerName.value || "").trim();
+    const typedCanonical = String(
+      sanitizeDemoLeaderboardName(typedPlayerName) || typedPlayerName
+    ).trim();
+    const previewNameKey = leaderboardPreviewNameKey(playerName.value);
 
     rows.forEach((row, index) => {
       let [playerRaw, rowHardFlag, , rowTrophy] = row;
@@ -370,9 +202,36 @@ export function createLeaderboardController(rt) {
         Number.isFinite(runScoreNum) &&
         scoreNum === runScoreNum &&
         trophyMatches;
-      const nameMatches = Boolean(playerStr) && playerStr === typedPlayerName;
+      const sameScoreAndTrophyAsRun =
+        hasScore &&
+        Number.isFinite(runScoreNum) &&
+        scoreNum === runScoreNum &&
+        trophyMatches;
+      const rowPreviewNameKey = leaderboardPreviewNameKey(playerStr);
+      const isLivePreviewRunRow =
+        sameScoreAndTrophyAsRun && rowPreviewNameKey === previewNameKey;
+      const isLiveInlineSelfRow =
+        !LEADERBOARD_USE_DEMO_DATA &&
+        !rt.getLiveLeaderboardSubmitUsed() &&
+        isLivePreviewRunRow;
+      const isLiveSubmittedSelfRow =
+        !LEADERBOARD_USE_DEMO_DATA &&
+        rt.getLiveLeaderboardSubmitUsed() &&
+        isLivePreviewRunRow;
+      const playerCanonical = String(
+        sanitizeDemoLeaderboardName(playerStr) || playerStr
+      ).trim();
+      const nameMatches =
+        Boolean(typedCanonical) &&
+        Boolean(playerCanonical) &&
+        playerCanonical === typedCanonical;
       const scoreMatches =
         scoreNum !== null && Number.isFinite(runScoreNum) && scoreNum === runScoreNum;
+      const nameMatchesHighlight =
+        nameMatches &&
+        scoreMatches &&
+        trophyMatches &&
+        (LEADERBOARD_USE_DEMO_DATA || rowPreviewNameKey === previewNameKey);
 
       let displayPlayer = playerStr;
       if (playerStr.toLowerCase() === "doughack") {
@@ -381,12 +240,12 @@ export function createLeaderboardController(rt) {
 
       if (hardFlag === 1) {
         color = redTextColorLeaderboard;
-      } else if (isDemoSelfRow) {
+      } else if (isDemoSelfRow || isLiveInlineSelfRow || isLiveSubmittedSelfRow) {
         rt.setPlayerPosition(index + 1);
         color = "white";
       } else if (playerStr.toLowerCase() === "doughack") {
         color = "magenta";
-      } else if (nameMatches && scoreMatches && trophyMatches) {
+      } else if (nameMatchesHighlight) {
         rt.setPlayerPosition(index + 1);
         color = "white";
       }
@@ -403,23 +262,32 @@ export function createLeaderboardController(rt) {
           : null;
       const submitRowBeigeNameTrophy =
         submittingSubPerfect &&
-        (isDemoSelfRow || (nameMatches && scoreMatches && trophyMatches));
+        (isDemoSelfRow ||
+          isLiveInlineSelfRow ||
+          isLiveSubmittedSelfRow ||
+          nameMatchesHighlight);
       const playerRowGoldNameTrophy =
         hardFlag !== 1 &&
         playerStr.toLowerCase() !== "doughack" &&
-        (isDemoSelfRow || (nameMatches && scoreMatches && trophyMatches)) &&
+        (isDemoSelfRow ||
+          isLiveInlineSelfRow ||
+          isLiveSubmittedSelfRow ||
+          nameMatchesHighlight) &&
         !submittingSubPerfect &&
         !nameTrophyFlash;
+
+      const useInlineNameCell =
+        (isDemoSelfRow && !rt.getDemoSubmitUsed()) || isLiveInlineSelfRow;
 
       const positionDisplay = `${index + 1}.`;
 
       [positionDisplay, displayNameCell, displayScoreCell, displayTrophyCell].forEach(
         (cellText, cellIndex) => {
           const td = document.createElement("td");
-          if (cellIndex === 1 && isDemoSelfRow && !rt.getDemoSubmitUsed()) {
-            td.dataset.demoSelfName = "1";
+          if (cellIndex === 1 && useInlineNameCell) {
+            td.dataset.inlineSelfName = "1";
             td.classList.add("leaderboard-name-cell--you-pseudo-select");
-            syncDemoSelfPseudoSelectSubPerfect(td, submittingSubPerfect);
+            syncLeaderboardNameCellSubPerfect(td, submittingSubPerfect);
             td.style.cursor = "pointer";
             if (submitRowBeigeNameTrophy)
               td.style.color = leaderboardSubPerfectRowColor;
@@ -446,7 +314,24 @@ export function createLeaderboardController(rt) {
 
     leaderboardTable.appendChild(thead);
     leaderboardTable.appendChild(tbody);
-    applyLeaderboardSubmitButtonVisibility(rows);
+
+    const qualifiesForBoardSlot = LEADERBOARD_USE_DEMO_DATA
+      ? demoRunQualifiesForLeaderboard(
+          LEADERBOARD_DEMO_EMPTY_BOARD ? [] : buildDemoLeaderboardRows(),
+          rt.getScore()
+        )
+      : demoRunQualifiesForLeaderboard(rows, rt.getScore()) &&
+        !rt.getLiveLeaderboardSubmitUsed();
+
+    applyLeaderboardSubmitButtonVisibility({
+      leaderboardUseDemoData: LEADERBOARD_USE_DEMO_DATA,
+      refs: refs(),
+      qualifiesForBoardSlot,
+      score: rt.getScore(),
+      scoreSubmitThreshold: SCORE_SUBMIT_THRESHOLD,
+      liveSubmitUsed: rt.getLiveLeaderboardSubmitUsed(),
+      demoSubmitUsed: rt.getDemoSubmitUsed(),
+    });
   }
 
   function finalizeDemoLeaderboardSubmit() {
@@ -543,6 +428,31 @@ export function createLeaderboardController(rt) {
     refs().playerName.classList.add("hiddenDisplay");
   }
 
+  function resolveLiveLeaderboardNameTrimForSubmit() {
+    const { leaderboardTable, playerName } = refs();
+    const inlineInput = leaderboardTable.querySelector(
+      ".leaderboard-inline-name-input"
+    );
+    if (inlineInput) {
+      const v = trimLeaderboardSubmitName(inlineInput.value);
+      playerName.value = v;
+      return v;
+    }
+    let t = trimLeaderboardSubmitName(playerName.value);
+    if (t !== "") return t;
+    if (LEADERBOARD_USE_DEMO_DATA) return "";
+    t = trimLeaderboardSubmitName(
+      leaderboardLiveSubmitNameFallbackRaw(
+        rt.getLiveLeaderboardPreviewRows?.(),
+        playerName.value,
+        rt.getScore(),
+        rt.getLongestWord()
+      )
+    );
+    if (t) playerName.value = t;
+    return t;
+  }
+
   async function refreshLeaderboardFromApi(clicked) {
     const { playerName, leaderboardButton } = refs();
     if (clicked) {
@@ -552,49 +462,93 @@ export function createLeaderboardController(rt) {
       leaderboardButton.style.backgroundColor = "gray";
     }
 
-    try {
-      const requestURL = `${rt.leaderboardLink}${rt.getLeaderboardPuzzleId()}`;
-      const requestOptions = {
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-        },
-      };
+    const nameTrim = resolveLiveLeaderboardNameTrimForSubmit();
+    const canPost = leaderboardCanPostLive(
+      clicked,
+      rt.getScore(),
+      nameTrim,
+      SCORE_SUBMIT_THRESHOLD
+    );
+    const deriveInput = {
+      clicked,
+      score: rt.getScore(),
+      nameTrim,
+      longestWord: rt.getLongestWord(),
+      scoreThreshold: SCORE_SUBMIT_THRESHOLD,
+      useDemoData: LEADERBOARD_USE_DEMO_DATA,
+      liveSubmitUsed: rt.getLiveLeaderboardSubmitUsed(),
+    };
+    let tableRows;
+    let committed = false;
 
-      const willSubmit =
-        rt.getScore() > SCORE_SUBMIT_THRESHOLD && playerName.value !== "";
-      if (willSubmit) {
-        const postBody = {
-          player: playerName.value,
-          score: rt.getScore(),
-          trophy: rt.getLongestWord(),
+    try {
+      try {
+        const requestURL = `${rt.leaderboardLink}${rt.getLeaderboardPuzzleId()}`;
+        const requestOptions = {
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+          },
         };
-        if (LEADERBOARD_SUBMIT_SCORE_VALIDATION) {
-          postBody.scoreValidation = rt.getScoreValidationTurns();
+        if (canPost) {
+          const postBody = {
+            player: nameTrim,
+            score: rt.getScore(),
+            trophy: rt.getLongestWord(),
+          };
+          if (LEADERBOARD_SUBMIT_SCORE_VALIDATION) {
+            postBody.scoreValidation = rt.getScoreValidationTurns();
+          }
+          requestOptions.method = "POST";
+          requestOptions.body = JSON.stringify(postBody);
         }
-        requestOptions.method = "POST";
-        requestOptions.body = JSON.stringify(postBody);
+
+        const response = await fetch(requestURL, requestOptions);
+        let raw = {};
+        try {
+          raw = await response.json();
+        } catch {}
+        ({ tableRows, committed } = deriveLiveLeaderboardAfterFetch(
+          { ok: response.ok, status: response.status, raw },
+          deriveInput
+        ));
+      } catch (err) {
+        leaderboardDebugWarn(err);
+        ({ tableRows, committed } = deriveLiveLeaderboardAfterFetch(
+          { ok: false, status: 0, raw: {} },
+          deriveInput
+        ));
       }
 
-      const response = await fetch(requestURL, requestOptions);
-      let raw = {};
-      try {
-        raw = await response.json();
-      } catch {}
-      const payload = parsedFetchPayload(raw);
-      const leaderboard = leaderboardRowsFromResponse(response, payload, willSubmit);
-
-      if (willSubmit && response.ok && leaderboardPostMessageIndicatesCommit(payload)) {
+      if (committed) {
         rt.playSound("submit", rt.getIsMuted());
         rt.setLiveLeaderboardSubmitUsed(true);
+        playerName.value = nameTrim;
       }
 
-      renderLeaderboardTable(leaderboard);
+      if (
+        !LEADERBOARD_USE_DEMO_DATA &&
+        Array.isArray(tableRows) &&
+        tableRows.length === 0 &&
+        rt.getLiveLeaderboardSubmitUsed()
+      ) {
+        const prev = rt.getLiveLeaderboardPreviewRows?.();
+        if (prev?.length) {
+          tableRows = prev.map((r) => r.slice());
+        }
+      }
+
+      renderLeaderboardTable(tableRows);
     } finally {
       if (clicked) {
         playerName.disabled = false;
-        leaderboardButton.disabled = false;
-        leaderboardButton.style.backgroundColor = "";
+        if (rt.getLiveLeaderboardSubmitUsed()) {
+          leaderboardButton.disabled = true;
+          leaderboardButton.style.backgroundColor = "rgba(95, 95, 95, 0.92)";
+        } else {
+          leaderboardButton.disabled = false;
+          leaderboardButton.style.removeProperty("background-color");
+        }
       }
     }
   }
@@ -657,7 +611,7 @@ export function createLeaderboardController(rt) {
       try {
         await refreshLeaderboardFromApi(false);
       } catch (err) {
-        console.error(err);
+        leaderboardDebugWarn(err);
       }
       requestAnimationFrame(() => {
         requestAnimationFrame(() => {
@@ -690,9 +644,7 @@ export function createLeaderboardController(rt) {
   }
 
   return {
-    findDemoSelfRowIndex,
-    openDemoLeaderboardInlineNameEdit,
-    applyLeaderboardSubmitButtonVisibility,
+    openLeaderboardInlineNameEdit,
     renderLeaderboardTable,
     finalizeDemoLeaderboardSubmit,
     finalizePostgameLeaderboardOverlayHidden,

--- a/package.json
+++ b/package.json
@@ -4,12 +4,16 @@
   "type": "module",
   "scripts": {
     "test": "node --test tests/",
+    "test:leaderboard": "node --test tests/leaderboard-*.test.js",
     "format": "prettier --write .",
     "gen:word-rec": "node scripts/export-word-recognizability.mjs",
     "gen:extend-metrics": "python3 scripts/build-extended-word-metrics.py",
     "gen:puzzle-pool": "node scripts/generate-puzzle-pool.mjs",
     "gen:puzzle-wordlist": "node scripts/export-puzzle-wordlist-seed.mjs",
-    "inventory:hints": "node scripts/inventory-puzzle-hints.mjs"
+    "inventory:hints": "node scripts/inventory-puzzle-hints.mjs",
+    "leaderboard-mock": "node scripts/leaderboard-mock-server.mjs",
+    "leaderboard-proxy": "node scripts/leaderboard-cors-proxy.mjs",
+    "dev:leaderboard": "node scripts/dev-leaderboard.mjs"
   },
   "devDependencies": {
     "prettier": "3.1.0"

--- a/scripts/dev-leaderboard.mjs
+++ b/scripts/dev-leaderboard.mjs
@@ -1,0 +1,50 @@
+/** Starts mock API then CORS proxy aimed at it (`LEADERBOARD_PROXY_TARGET`). Ctrl+C to stop. */
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, "..");
+const mockPort = process.env.LEADERBOARD_MOCK_PORT || "9777";
+const node = process.execPath;
+
+const children = [];
+
+const mock = spawn(node, [join(root, "scripts/leaderboard-mock-server.mjs")], {
+  cwd: root,
+  env: { ...process.env, LEADERBOARD_MOCK_PORT: mockPort },
+  stdio: "inherit",
+});
+children.push(mock);
+
+mock.on("exit", (code) => {
+  if (code != null && code !== 0) process.exit(code);
+});
+
+function startProxy() {
+  const target = `http://127.0.0.1:${mockPort}`;
+  const proxy = spawn(node, [join(root, "scripts/leaderboard-cors-proxy.mjs")], {
+    cwd: root,
+    env: {
+      ...process.env,
+      LEADERBOARD_PROXY_TARGET: target,
+    },
+    stdio: "inherit",
+  });
+  children.push(proxy);
+  proxy.on("exit", (code) => process.exit(code ?? 0));
+}
+
+setTimeout(startProxy, 250);
+
+function shutdown() {
+  for (const c of children) {
+    try {
+      c.kill("SIGTERM");
+    } catch {
+      /* ignore */
+    }
+  }
+}
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);

--- a/scripts/leaderboard-cors-proxy.mjs
+++ b/scripts/leaderboard-cors-proxy.mjs
@@ -1,0 +1,90 @@
+/**
+ * CORS proxy for local dev. Prefer `npm run dev:leaderboard` (mock + proxy). Otherwise set `LEADERBOARD_PROXY_TARGET` (origin only).
+ * Default upstream is production host from `js/config.js`. Env: `LEADERBOARD_PROXY_PORT` (8765).
+ */
+import http from "node:http";
+import { LEADERBOARD_PRODUCTION_API_BASE } from "../js/config.js";
+
+const UPSTREAM_RAW =
+  process.env.LEADERBOARD_PROXY_TARGET ||
+  new URL(LEADERBOARD_PRODUCTION_API_BASE).origin;
+const UPSTREAM = UPSTREAM_RAW.replace(/\/$/, "");
+const PORT = Number(process.env.LEADERBOARD_PROXY_PORT || 8765);
+
+const CORS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type",
+  "Access-Control-Max-Age": "86400",
+};
+
+function forwardHeaderPairs(req) {
+  const out = [];
+  const allow = new Set(["content-type", "accept", "accept-language", "user-agent"]);
+  for (const [k, v] of Object.entries(req.headers)) {
+    if (!allow.has(k.toLowerCase()) || v == null) continue;
+    const val = Array.isArray(v) ? v.join(",") : v;
+    out.push([k, val]);
+  }
+  return out;
+}
+
+function readRawBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req.on("data", (c) => chunks.push(c));
+    req.on("end", () => resolve(Buffer.concat(chunks)));
+    req.on("error", reject);
+  });
+}
+
+const server = http.createServer(async (req, res) => {
+  for (const [k, v] of Object.entries(CORS)) {
+    res.setHeader(k, v);
+  }
+
+  if (req.method === "OPTIONS") {
+    res.writeHead(204);
+    res.end();
+    return;
+  }
+
+  let pathQuery = req.url || "/";
+  if (!pathQuery.startsWith("/")) pathQuery = `/${pathQuery}`;
+
+  const targetUrl = `${UPSTREAM}${pathQuery}`;
+  let body;
+  if (req.method !== "GET" && req.method !== "HEAD") {
+    body = await readRawBody(req);
+  }
+
+  const init = {
+    method: req.method || "GET",
+    headers: Object.fromEntries(forwardHeaderPairs(req)),
+  };
+  if (body && body.length > 0) {
+    init.body = body;
+  }
+
+  let fr;
+  try {
+    fr = await fetch(targetUrl, init);
+  } catch (e) {
+    console.error("leaderboard-proxy fetch failed:", e.message || e);
+    res.writeHead(502, { "Content-Type": "text/plain; charset=utf-8" });
+    res.end("Bad gateway (upstream unreachable)");
+    return;
+  }
+
+  const buf = Buffer.from(await fr.arrayBuffer());
+  res.writeHead(fr.status, {
+    "Content-Type": fr.headers.get("content-type") || "application/json",
+  });
+  res.end(buf);
+});
+
+server.listen(PORT, "127.0.0.1", () => {
+  console.log(
+    `Leaderboard CORS proxy http://127.0.0.1:${PORT} → ${UPSTREAM} (stop with Ctrl+C)`
+  );
+});

--- a/scripts/leaderboard-mock-server.mjs
+++ b/scripts/leaderboard-mock-server.mjs
@@ -1,0 +1,111 @@
+/**
+ * Local `/leaderboard/*` stub. Use `npm run dev:leaderboard` or aim the proxy with `LEADERBOARD_PROXY_TARGET`.
+ * Env: `LEADERBOARD_MOCK_PORT` (default 9777), `LEADERBOARD_MOCK_SCENARIO` (success|profanity|400|array|empty).
+ */
+import http from "node:http";
+
+const PORT = Number(process.env.LEADERBOARD_MOCK_PORT || 9777);
+const SCENARIO = String(process.env.LEADERBOARD_MOCK_SCENARIO || "success")
+  .trim()
+  .toLowerCase();
+
+function json(res, status, body) {
+  const s = JSON.stringify(body);
+  res.writeHead(status, {
+    "Content-Type": "application/json; charset=utf-8",
+    "Content-Length": Buffer.byteLength(s),
+  });
+  res.end(s);
+}
+
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req.on("data", (c) => chunks.push(c));
+    req.on("end", () => resolve(Buffer.concat(chunks)));
+    req.on("error", reject);
+  });
+}
+
+function parsePostPlayer(bodyBuf) {
+  if (!bodyBuf || bodyBuf.length === 0) return null;
+  try {
+    const o = JSON.parse(bodyBuf.toString("utf8"));
+    if (o && typeof o === "object") {
+      return {
+        player: String(o.player ?? "").trim() || "YOU",
+        score: Number(o.score) || 0,
+        trophy: String(o.trophy ?? "").trim() || "",
+      };
+    }
+  } catch {
+    /* ignore */
+  }
+  return null;
+}
+
+function successTop10FromPost(parsed) {
+  const p = parsed || { player: "YOU", score: 0, trophy: "" };
+  return {
+    message: "Record inserted successfully.",
+    top_10: [
+      ["Bob", 100, "zzz"],
+      [p.player, p.score, p.trophy],
+    ],
+  };
+}
+
+const server = http.createServer(async (req, res) => {
+  const url = req.url || "/";
+  console.log(`[leaderboard-mock] ${req.method} ${url}`);
+
+  if (!url.startsWith("/leaderboard/")) {
+    res.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" });
+    res.end("Not found");
+    return;
+  }
+
+  if (req.method === "GET") {
+    json(res, 200, []);
+    return;
+  }
+
+  if (req.method === "POST") {
+    const raw = await readBody(req);
+    const parsed = parsePostPlayer(raw);
+
+    if (SCENARIO === "400") {
+      json(res, 400, {});
+      return;
+    }
+    if (SCENARIO === "profanity") {
+      json(res, 200, {
+        message: "Profanity rejected",
+        top_10: [["Ada", 88, "STAR"]],
+      });
+      return;
+    }
+    if (SCENARIO === "array") {
+      const p = parsed || { player: "Ada", score: 88, trophy: "STAR" };
+      json(res, 200, [
+        ["Zoe", 90, "SUN"],
+        [p.player, p.score, p.trophy],
+      ]);
+      return;
+    }
+    if (SCENARIO === "empty") {
+      json(res, 200, {});
+      return;
+    }
+
+    json(res, 200, successTop10FromPost(parsed));
+    return;
+  }
+
+  res.writeHead(405, { "Content-Type": "text/plain; charset=utf-8" });
+  res.end("Method not allowed");
+});
+
+server.listen(PORT, "127.0.0.1", () => {
+  console.log(`[leaderboard-mock] http://127.0.0.1:${PORT} scenario=${SCENARIO}`);
+});

--- a/style.css
+++ b/style.css
@@ -45,7 +45,7 @@
   --perfect-hunt-starter-hint-glow-blur-static: 14px;
   --perfect-hunt-starter-hint-glow-spread-static: 2px;
   --grid-button-text-color: white;
-  --leaderboard-button-background-color: #ed3d02;
+  --leaderboard-button-background-color: #000000;
   --leaderboard-button-text-color: white;
   --button-background-color: #ffffff;
   --button-text-color: hwb(275 16% 5%);

--- a/tests/leaderboard-client.test.js
+++ b/tests/leaderboard-client.test.js
@@ -1,0 +1,186 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  top10RowsFromPayload,
+  leaderboardRowsFromResponse,
+  leaderboardPostMessageIndicatesCommit,
+  leaderboardPostTreatAsCommitted,
+  parsedFetchPayload,
+  normalizeLeaderboardRows,
+} from "../js/leaderboard-api.js";
+import {
+  applyLiveLeaderboardPreviewMerge,
+  leaderboardLiveSelfRowIndex,
+  leaderboardLiveSubmitNameFallbackRaw,
+  mergeDemoRunIntoTop10,
+} from "../js/leaderboard-lifecycle.js";
+import { leaderboardNumericScore } from "../js/leaderboard-ui-helpers.js";
+
+test("top10RowsFromPayload: Flask GET root array and empty POST object", () => {
+  assert.deepEqual(top10RowsFromPayload([]), []);
+  assert.deepEqual(top10RowsFromPayload([["a", 1, "t"]]), [["a", 1, "t"]]);
+  assert.deepEqual(top10RowsFromPayload({ top_10: [["b", 2, "u"]] }), [["b", 2, "u"]]);
+  assert.deepEqual(top10RowsFromPayload({ top10: [["c", 3, "v"]] }), [["c", 3, "v"]]);
+  assert.deepEqual(top10RowsFromPayload({ leaderboard: [["d", 4, "w"]] }), [
+    ["d", 4, "w"],
+  ]);
+  assert.deepEqual(top10RowsFromPayload({ message: "x" }), []);
+});
+
+test("leaderboardRowsFromResponse: ok GET uses array; ok POST uses top_10", () => {
+  const ok = { ok: true };
+  assert.deepEqual(leaderboardRowsFromResponse(ok, [["Ada", 88, "star"]], false), [
+    ["Ada", 88, "star"],
+  ]);
+  assert.deepEqual(
+    leaderboardRowsFromResponse(
+      ok,
+      { message: "ok", top_10: [["Ada", 88, "star"]] },
+      true
+    ),
+    [["Ada", 88, "star"]]
+  );
+});
+
+test("leaderboardPostMessageIndicatesCommit", () => {
+  assert.equal(
+    leaderboardPostMessageIndicatesCommit({ message: "Record inserted successfully." }),
+    true
+  );
+  assert.equal(
+    leaderboardPostMessageIndicatesCommit({ message: "This record already exists." }),
+    true
+  );
+  assert.equal(
+    leaderboardPostMessageIndicatesCommit({ message: "Profanity rejected" }),
+    false
+  );
+  assert.equal(leaderboardPostMessageIndicatesCommit({}), false);
+});
+
+test("leaderboardPostTreatAsCommitted", () => {
+  assert.equal(leaderboardPostTreatAsCommitted(false, {}, true), false);
+  assert.equal(leaderboardPostTreatAsCommitted(true, {}, true), true);
+  assert.equal(
+    leaderboardPostTreatAsCommitted(true, { message: "Profanity rejected" }, true),
+    false
+  );
+  assert.equal(leaderboardPostTreatAsCommitted(true, { error: "bad" }, true), false);
+  assert.equal(
+    leaderboardPostTreatAsCommitted(true, { top_10: [["a", 1, "t"]] }, true),
+    true
+  );
+  assert.equal(
+    leaderboardPostTreatAsCommitted(
+      true,
+      { message: "Record inserted successfully." },
+      true
+    ),
+    true
+  );
+  assert.equal(
+    leaderboardPostTreatAsCommitted(
+      true,
+      { message: "Your score was recorded." },
+      true
+    ),
+    true
+  );
+});
+
+test("parsedFetchPayload: API Gateway body string", () => {
+  assert.deepEqual(parsedFetchPayload({ body: '{"top_10":[],"message":"x"}' }), {
+    top_10: [],
+    message: "x",
+  });
+  assert.deepEqual(parsedFetchPayload({ body: "not json" }), {});
+});
+
+test("mergeDemoRunIntoTop10: removes prior row same name+score+trophy before insert", () => {
+  const base = normalizeLeaderboardRows([
+    ["YOU", 88, "blinders"],
+    ["TOMMY", 88, "blinders"],
+  ]);
+  const merged = mergeDemoRunIntoTop10(base, "YOU", 88, "blinders");
+  const you888 = merged.filter(
+    (r) =>
+      String(r[0]).toUpperCase() === "YOU" &&
+      r[2] === 88 &&
+      String(r[3]).toLowerCase() === "blinders"
+  );
+  assert.equal(you888.length, 1);
+  assert.ok(merged.some((r) => String(r[0]).toUpperCase() === "TOMMY" && r[2] === 88));
+});
+
+test("mergeDemoRunIntoTop10: same score preserves API order; new row ranks last among ties", () => {
+  const base = normalizeLeaderboardRows([
+    ["ALEX", 100, "ZEBRA"],
+    ["BETH", 100, "YAK"],
+  ]);
+  const merged = mergeDemoRunIntoTop10(base, "CARLA", 100, "XRAY");
+  const ranks = merged
+    .filter((r) => r[0] && leaderboardNumericScore(r) === 100)
+    .map((r) => r[0]);
+  assert.deepEqual(ranks, ["ALEX", "BETH", "CARLA"]);
+});
+
+test("leaderboardLiveSubmitNameFallbackRaw: single matching row when field empty", () => {
+  const rows = normalizeLeaderboardRows([["BOB", 50, "Z"]]);
+  assert.equal(leaderboardLiveSubmitNameFallbackRaw(rows, "", 50, "Z"), "BOB");
+});
+
+test("leaderboardLiveSubmitNameFallbackRaw: disambiguate by preview key when field empty", () => {
+  const rows = normalizeLeaderboardRows([
+    ["TOMMY", 50, "Z"],
+    ["YOU", 50, "Z"],
+  ]);
+  assert.equal(leaderboardLiveSubmitNameFallbackRaw(rows, "", 50, "Z"), "YOU");
+});
+
+test("leaderboardLiveSelfRowIndex: name key distinguishes preview row", () => {
+  const rows = normalizeLeaderboardRows([
+    ["TOMMY", 50, "Z"],
+    ["YOU", 50, "Z"],
+  ]);
+  assert.equal(leaderboardLiveSelfRowIndex(rows, "", 50, "Z"), 1);
+  assert.equal(leaderboardLiveSelfRowIndex(rows, "TOMMY", 50, "Z"), 0);
+});
+
+test("applyLiveLeaderboardPreviewMerge: no duplicate YOU when API already has this run", () => {
+  const norm = normalizeLeaderboardRows([
+    ["YOU", 88, "blinders"],
+    ["TOMMY", 88, "blinders"],
+  ]);
+  const merged = applyLiveLeaderboardPreviewMerge(norm, "", 88, "blinders", {
+    useDemoData: false,
+    liveSubmitUsed: false,
+  });
+  const youCount = merged.filter(
+    (r) => String(r[0]).toUpperCase() === "YOU" && r[2] === 88
+  ).length;
+  assert.equal(youCount, 1);
+});
+
+test("applyLiveLeaderboardPreviewMerge: empty GET + qualifying score shows player", () => {
+  const norm = normalizeLeaderboardRows([]);
+  const merged = applyLiveLeaderboardPreviewMerge(norm, "Ada", 88, "STAR", {
+    useDemoData: false,
+    liveSubmitUsed: false,
+  });
+  assert.equal(merged[0][0], "Ada");
+  assert.equal(merged[0][2], 88);
+  assert.equal(merged.length, 10);
+});
+
+test("applyLiveLeaderboardPreviewMerge: skipped after submit or in demo", () => {
+  const norm = normalizeLeaderboardRows([]);
+  const optsA = { useDemoData: false, liveSubmitUsed: true };
+  assert.deepEqual(applyLiveLeaderboardPreviewMerge(norm, "Ada", 88, "X", optsA), norm);
+  const optsB = { useDemoData: true, liveSubmitUsed: false };
+  assert.deepEqual(applyLiveLeaderboardPreviewMerge(norm, "Ada", 88, "X", optsB), norm);
+});
+
+test("normalizeLeaderboardRows: API 3-tuple to internal 4-field row", () => {
+  const [r] = normalizeLeaderboardRows([["Ada", 88, "star"]]);
+  assert.deepEqual(r, ["Ada", 0, 88, "star"]);
+});

--- a/tests/leaderboard-mock-api.test.js
+++ b/tests/leaderboard-mock-api.test.js
@@ -1,0 +1,191 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { SCORE_SUBMIT_THRESHOLD } from "../js/config.js";
+import { deriveLiveLeaderboardAfterFetch } from "../js/leaderboard-live-flow.js";
+import { normalizeLeaderboardRows } from "../js/leaderboard-api.js";
+
+const EMPTY_PAD = ["", 0, "", ""];
+
+const baseInput = {
+  scoreThreshold: SCORE_SUBMIT_THRESHOLD,
+  useDemoData: false,
+  liveSubmitUsed: false,
+  longestWord: "STAR",
+};
+
+test("GET [] + qualifying run: preview merge shows player at row 1", () => {
+  const { tableRows, committed, canPost } = deriveLiveLeaderboardAfterFetch(
+    { ok: true, raw: [] },
+    {
+      ...baseInput,
+      clicked: false,
+      score: 88,
+      nameTrim: "Ada",
+    }
+  );
+  assert.equal(canPost, false);
+  assert.equal(committed, false);
+  assert.equal(tableRows[0][0], "Ada");
+  assert.equal(tableRows[0][2], 88);
+});
+
+test("clicked at minimum score: no POST, no preview merge on GET []", () => {
+  const { tableRows, committed, canPost } = deriveLiveLeaderboardAfterFetch(
+    { ok: true, raw: [] },
+    {
+      ...baseInput,
+      clicked: true,
+      score: SCORE_SUBMIT_THRESHOLD,
+      nameTrim: "Ada",
+    }
+  );
+  assert.equal(canPost, false);
+  assert.equal(committed, false);
+  assert.equal(tableRows.length, 0);
+});
+
+test("GET [] + score 1: preview merge shows player (above minimum)", () => {
+  const { tableRows, canPost } = deriveLiveLeaderboardAfterFetch(
+    { ok: true, raw: [] },
+    {
+      ...baseInput,
+      clicked: false,
+      score: 1,
+      nameTrim: "Ada",
+    }
+  );
+  assert.equal(canPost, false);
+  assert.equal(tableRows[0][0], "Ada");
+  assert.equal(tableRows[0][2], 1);
+});
+
+test("clicked but empty name: canPost false, preview merge", () => {
+  const { canPost, committed, tableRows } = deriveLiveLeaderboardAfterFetch(
+    { ok: true, raw: [] },
+    {
+      ...baseInput,
+      clicked: true,
+      score: 88,
+      nameTrim: "   ",
+    }
+  );
+  assert.equal(canPost, false);
+  assert.equal(committed, false);
+  assert.equal(tableRows[0][2], 88);
+});
+
+test("POST success + commit message: rows from top_10, committed", () => {
+  const top10 = [
+    ["Bob", 100, "zzz"],
+    ["Ada", 88, "STAR"],
+  ];
+  const raw = {
+    message: "Record inserted successfully.",
+    top_10: top10,
+  };
+  const { tableRows, committed, canPost } = deriveLiveLeaderboardAfterFetch(
+    { ok: true, raw },
+    {
+      ...baseInput,
+      clicked: true,
+      score: 88,
+      nameTrim: "Ada",
+    }
+  );
+  assert.equal(canPost, true);
+  assert.equal(committed, true);
+  assert.equal(tableRows.length, 10);
+  assert.deepEqual(tableRows[0], ["Bob", 0, 100, "zzz"]);
+  assert.deepEqual(tableRows[1], ["Ada", 0, 88, "STAR"]);
+  assert.deepEqual(tableRows.slice(2), Array(8).fill(EMPTY_PAD));
+});
+
+test("POST 200 soft-fail message: not committed, still returns top_10", () => {
+  const top10 = [["Ada", 88, "STAR"]];
+  const { tableRows, committed } = deriveLiveLeaderboardAfterFetch(
+    { ok: true, raw: { message: "Profanity rejected", top_10: top10 } },
+    {
+      ...baseInput,
+      clicked: true,
+      score: 88,
+      nameTrim: "Ada",
+    }
+  );
+  assert.equal(committed, false);
+  assert.equal(tableRows.length, 10);
+  assert.deepEqual(tableRows[0], normalizeLeaderboardRows(top10)[0]);
+  assert.deepEqual(tableRows.slice(1), Array(9).fill(EMPTY_PAD));
+});
+
+test("POST !ok with empty payload: preview fallback, not committed", () => {
+  const { tableRows, committed } = deriveLiveLeaderboardAfterFetch(
+    { ok: false, status: 400, raw: {} },
+    {
+      ...baseInput,
+      clicked: true,
+      score: 88,
+      nameTrim: "Ada",
+    }
+  );
+  assert.equal(committed, false);
+  assert.equal(tableRows.length, 10);
+  assert.equal(tableRows[0][0], "Ada");
+});
+
+test("POST 200 root JSON array (same as GET): populates table from response only", () => {
+  const rows = [
+    ["Zoe", 90, "SUN"],
+    ["Ada", 88, "STAR"],
+  ];
+  const { tableRows, committed, canPost } = deriveLiveLeaderboardAfterFetch(
+    { ok: true, raw: rows },
+    {
+      ...baseInput,
+      clicked: true,
+      score: 88,
+      nameTrim: "Ada",
+    }
+  );
+  assert.equal(canPost, true);
+  assert.equal(committed, true);
+  assert.equal(tableRows.length, 10);
+  assert.deepEqual(tableRows[0], ["Zoe", 0, 90, "SUN"]);
+  assert.deepEqual(tableRows[1], ["Ada", 0, 88, "STAR"]);
+  assert.deepEqual(tableRows.slice(2), Array(8).fill(EMPTY_PAD));
+});
+
+test("POST 200 empty object: committed; rows only from server (empty here)", () => {
+  const { tableRows, committed, canPost } = deriveLiveLeaderboardAfterFetch(
+    { ok: true, raw: {} },
+    {
+      ...baseInput,
+      clicked: true,
+      score: 88,
+      nameTrim: "Ada",
+    }
+  );
+  assert.equal(canPost, true);
+  assert.equal(committed, true);
+  assert.deepEqual(tableRows, []);
+});
+
+test("Lambda API Gateway envelope: parse body then same commit + rows", () => {
+  const top10 = [["Ada", 88, "STAR"]];
+  const inner = {
+    message: "Record inserted successfully.",
+    top_10: top10,
+  };
+  const { tableRows, committed } = deriveLiveLeaderboardAfterFetch(
+    { ok: true, raw: { body: JSON.stringify(inner) } },
+    {
+      ...baseInput,
+      clicked: true,
+      score: 88,
+      nameTrim: "Ada",
+    }
+  );
+  assert.equal(committed, true);
+  assert.equal(tableRows.length, 10);
+  assert.deepEqual(tableRows[0], ["Ada", 0, 88, "STAR"]);
+  assert.deepEqual(tableRows.slice(1), Array(9).fill(EMPTY_PAD));
+});


### PR DESCRIPTION
- Only the preview row (matching name key + score + trophy) is inline-editable; existing API rows stay read-only when stats match.
- Submit resolves player name from inline input, hidden field, or preview grid fallback so POST matches what the player typed.
- Tie scores: merge keeps API order and places the preview run after same-score rows from the server.
- Split leaderboard into api, lifecycle, live-flow, and ui helper modules; add mock server, CORS proxy, and npm test targets.
- Gate debug logging and tighten config around production API base URL.