### PR TITLE
Leaderboard: tag current-run preview; fix same-score replay UI

### DIFF
--- a/js/leaderboard-api.js
+++ b/js/leaderboard-api.js
@@ -1,12 +1,19 @@
+/** Client-only row tag for the current-run preview (never from the API). */
+export const LEADERBOARD_META_LIVE_PREVIEW = "live-preview";
+
 export function normalizeLeaderboardRow(row) {
   if (!Array.isArray(row)) return ["", 0, "", ""];
   if (row.length >= 4) {
-    return [
+    const out = [
       String(row[0] ?? ""),
       Number(row[1]) === 1 ? 1 : 0,
       row[2],
       String(row[3] ?? ""),
     ];
+    if (row[4] === LEADERBOARD_META_LIVE_PREVIEW) {
+      out.push(LEADERBOARD_META_LIVE_PREVIEW);
+    }
+    return out;
   }
   if (row.length >= 3) {
     return [String(row[0] ?? ""), 0, row[1], String(row[2] ?? "")];

--- a/js/leaderboard-lifecycle.js
+++ b/js/leaderboard-lifecycle.js
@@ -1,4 +1,5 @@
 import { DEMO_LEADERBOARD_NAME_MAX, SCORE_SUBMIT_THRESHOLD } from "./config.js";
+import { LEADERBOARD_META_LIVE_PREVIEW } from "./leaderboard-api.js";
 import { leaderboardNumericScore } from "./leaderboard-ui-helpers.js";
 
 export function sanitizeDemoLeaderboardName(raw) {
@@ -15,7 +16,6 @@ export function leaderboardPreviewNameKey(raw) {
   return sanitizeDemoLeaderboardName(t) || t;
 }
 
-/** Preview row index for inline edit: same run (score + trophy) and same name key as the field. */
 export function leaderboardLiveSelfRowIndex(
   rows,
   playerNameValue,
@@ -26,15 +26,22 @@ export function leaderboardLiveSelfRowIndex(
   const trophy = String(longestWord ?? "").trim();
   const want = Number(runScore);
   const previewKey = leaderboardPreviewNameKey(playerNameValue);
-  return rows.findIndex(
-    (r) =>
-      leaderboardNumericScore(r) === want &&
-      String(r[3] || "").trim() === trophy &&
-      leaderboardPreviewNameKey(r[0]) === previewKey
-  );
+  let untagged = -1;
+  for (let i = 0; i < rows.length; i++) {
+    const r = rows[i];
+    if (
+      leaderboardNumericScore(r) !== want ||
+      String(r[3] || "").trim() !== trophy ||
+      leaderboardPreviewNameKey(r[0]) !== previewKey
+    ) {
+      continue;
+    }
+    if (r[4] === LEADERBOARD_META_LIVE_PREVIEW) return i;
+    if (untagged < 0) untagged = i;
+  }
+  return untagged;
 }
 
-/** POST name from preview rows when #player-name is empty. */
 export function leaderboardLiveSubmitNameFallbackRaw(
   rows,
   playerNameValue,
@@ -52,6 +59,15 @@ export function leaderboardLiveSubmitNameFallbackRaw(
   }
   if (!matches.length) return "";
   const previewKey = leaderboardPreviewNameKey(playerNameValue);
+  const keyedTagged = matches.find(
+    (r) =>
+      r[4] === LEADERBOARD_META_LIVE_PREVIEW &&
+      leaderboardPreviewNameKey(r[0]) === previewKey
+  );
+  if (keyedTagged) {
+    const raw = String(keyedTagged[0] ?? "").trim();
+    return raw || "YOU";
+  }
   const keyed = matches.find((r) => leaderboardPreviewNameKey(r[0]) === previewKey);
   if (keyed) {
     const raw = String(keyed[0] ?? "").trim();
@@ -115,11 +131,14 @@ export function applyLiveLeaderboardPreviewMerge(
     normalizedApiRows,
     trimmedPlayerName || "YOU",
     run,
-    String(longestWord || "").trim()
+    String(longestWord || "").trim(),
+    { dedupeNameScoreTrophy: false, tagLiveRunPreview: true }
   );
 }
 
-export function mergeDemoRunIntoTop10(baseRows, name, runScore, trophy) {
+export function mergeDemoRunIntoTop10(baseRows, name, runScore, trophy, mergeOpts) {
+  const dedupeNameScoreTrophy = !mergeOpts || mergeOpts.dedupeNameScoreTrophy !== false;
+  const tagLiveRunPreview = Boolean(mergeOpts?.tagLiveRunPreview);
   const filled = baseRows.map((r, idx) => {
     return [
       String(r[0] || ""),
@@ -137,24 +156,34 @@ export function mergeDemoRunIntoTop10(baseRows, name, runScore, trophy) {
     .trim()
     .toUpperCase();
   const scoreNum = Number(runScore);
-  const deduped = dataRows.filter((r) => {
-    const sameScore = Number(r[2]) === scoreNum;
-    const sameTrophy =
-      String(r[3] || "")
-        .trim()
-        .toUpperCase() === trophyKey;
-    const sameName = sanitizeDemoLeaderboardName(r[0]) === nameKey;
-    return !(sameScore && sameTrophy && sameName);
-  });
+  let deduped = dataRows;
+  if (dedupeNameScoreTrophy) {
+    deduped = dataRows.filter((r) => {
+      const sameScore = Number(r[2]) === scoreNum;
+      const sameTrophy =
+        String(r[3] || "")
+          .trim()
+          .toUpperCase() === trophyKey;
+      const sameName = sanitizeDemoLeaderboardName(r[0]) === nameKey;
+      return !(sameScore && sameTrophy && sameName);
+    });
+  }
   const maxOrder = deduped.length === 0 ? -1 : Math.max(...deduped.map((r) => r[4]));
-  const newRow = [name, 0, runScore, String(trophy || ""), maxOrder + 1];
+  const previewTieOrder = maxOrder + 1;
+  const newRow = [name, 0, runScore, String(trophy || ""), previewTieOrder];
   deduped.push(newRow);
   deduped.sort((a, b) => {
     const byScore = Number(b[2]) - Number(a[2]);
     if (byScore !== 0) return byScore;
     return Number(a[4]) - Number(b[4]);
   });
-  const next = deduped.slice(0, 10).map((r) => r.slice(0, 4));
+  const next = deduped.slice(0, 10).map((r) => {
+    const four = [r[0], r[1], r[2], r[3]];
+    if (tagLiveRunPreview && Number(r[4]) === previewTieOrder) {
+      four.push(LEADERBOARD_META_LIVE_PREVIEW);
+    }
+    return four;
+  });
   while (next.length < 10) {
     next.push(["", 0, "", ""]);
   }

--- a/js/leaderboard-ui.js
+++ b/js/leaderboard-ui.js
@@ -16,6 +16,7 @@ import {
   normalizeLeaderboardRows,
   leaderboardDebugWarn,
   padNormalizedLeaderboardToTop10,
+  LEADERBOARD_META_LIVE_PREVIEW,
 } from "./leaderboard-api.js";
 import {
   buildDemoLeaderboardRows,
@@ -159,7 +160,7 @@ export function createLeaderboardController(rt) {
     );
     if (!LEADERBOARD_USE_DEMO_DATA) {
       rows = padNormalizedLeaderboardToTop10(rows);
-      rt.setLiveLeaderboardPreviewRows(rows.map((r) => r.slice()));
+      rt.setLiveLeaderboardPreviewRows(rows.map((r) => r.slice(0, 5)));
     }
     const headerRow = document.createElement("tr");
     ["", "👤", "🏹", "🏆"].forEach((headerText) => {
@@ -208,16 +209,18 @@ export function createLeaderboardController(rt) {
         scoreNum === runScoreNum &&
         trophyMatches;
       const rowPreviewNameKey = leaderboardPreviewNameKey(playerStr);
-      const isLivePreviewRunRow =
+      const isLiveStatsAndNameMatch =
         sameScoreAndTrophyAsRun && rowPreviewNameKey === previewNameKey;
+      const isLiveCurrentRunPreviewRow =
+        isLiveStatsAndNameMatch && row[4] === LEADERBOARD_META_LIVE_PREVIEW;
       const isLiveInlineSelfRow =
         !LEADERBOARD_USE_DEMO_DATA &&
         !rt.getLiveLeaderboardSubmitUsed() &&
-        isLivePreviewRunRow;
+        isLiveCurrentRunPreviewRow;
       const isLiveSubmittedSelfRow =
         !LEADERBOARD_USE_DEMO_DATA &&
         rt.getLiveLeaderboardSubmitUsed() &&
-        isLivePreviewRunRow;
+        isLiveStatsAndNameMatch;
       const playerCanonical = String(
         sanitizeDemoLeaderboardName(playerStr) || playerStr
       ).trim();
@@ -231,7 +234,10 @@ export function createLeaderboardController(rt) {
         nameMatches &&
         scoreMatches &&
         trophyMatches &&
-        (LEADERBOARD_USE_DEMO_DATA || rowPreviewNameKey === previewNameKey);
+        (LEADERBOARD_USE_DEMO_DATA ||
+          (rowPreviewNameKey === previewNameKey &&
+            (rt.getLiveLeaderboardSubmitUsed() ||
+              row[4] === LEADERBOARD_META_LIVE_PREVIEW)));
 
       let displayPlayer = playerStr;
       if (playerStr.toLowerCase() === "doughack") {

--- a/tests/leaderboard-client.test.js
+++ b/tests/leaderboard-client.test.js
@@ -7,6 +7,7 @@ import {
   leaderboardPostTreatAsCommitted,
   parsedFetchPayload,
   normalizeLeaderboardRows,
+  LEADERBOARD_META_LIVE_PREVIEW,
 } from "../js/leaderboard-api.js";
 import {
   applyLiveLeaderboardPreviewMerge,
@@ -131,22 +132,23 @@ test("leaderboardLiveSubmitNameFallbackRaw: single matching row when field empty
 
 test("leaderboardLiveSubmitNameFallbackRaw: disambiguate by preview key when field empty", () => {
   const rows = normalizeLeaderboardRows([
-    ["TOMMY", 50, "Z"],
-    ["YOU", 50, "Z"],
+    ["TOMMY", 0, 50, "Z"],
+    ["YOU", 0, 50, "Z", LEADERBOARD_META_LIVE_PREVIEW],
   ]);
   assert.equal(leaderboardLiveSubmitNameFallbackRaw(rows, "", 50, "Z"), "YOU");
 });
 
-test("leaderboardLiveSelfRowIndex: name key distinguishes preview row", () => {
+test("leaderboardLiveSelfRowIndex: prefers tagged current-run preview row", () => {
   const rows = normalizeLeaderboardRows([
-    ["TOMMY", 50, "Z"],
-    ["YOU", 50, "Z"],
+    ["YOU", 0, 50, "Z"],
+    ["TOMMY", 0, 50, "Z"],
+    ["YOU", 0, 50, "Z", LEADERBOARD_META_LIVE_PREVIEW],
   ]);
-  assert.equal(leaderboardLiveSelfRowIndex(rows, "", 50, "Z"), 1);
-  assert.equal(leaderboardLiveSelfRowIndex(rows, "TOMMY", 50, "Z"), 0);
+  assert.equal(leaderboardLiveSelfRowIndex(rows, "", 50, "Z"), 2);
+  assert.equal(leaderboardLiveSelfRowIndex(rows, "TOMMY", 50, "Z"), 1);
 });
 
-test("applyLiveLeaderboardPreviewMerge: no duplicate YOU when API already has this run", () => {
+test("applyLiveLeaderboardPreviewMerge: keeps API row; adds preview below on same name/score/trophy", () => {
   const norm = normalizeLeaderboardRows([
     ["YOU", 88, "blinders"],
     ["TOMMY", 88, "blinders"],
@@ -155,10 +157,15 @@ test("applyLiveLeaderboardPreviewMerge: no duplicate YOU when API already has th
     useDemoData: false,
     liveSubmitUsed: false,
   });
-  const youCount = merged.filter(
+  const youRows = merged.filter(
     (r) => String(r[0]).toUpperCase() === "YOU" && r[2] === 88
-  ).length;
-  assert.equal(youCount, 1);
+  );
+  assert.equal(youRows.length, 2);
+  const previewIdx = merged.findIndex((r) => r[4] === LEADERBOARD_META_LIVE_PREVIEW);
+  const firstYouIdx = merged.findIndex(
+    (r) => String(r[0]).toUpperCase() === "YOU" && r[2] === 88 && r.length < 5
+  );
+  assert.ok(firstYouIdx >= 0 && previewIdx > firstYouIdx);
 });
 
 test("applyLiveLeaderboardPreviewMerge: empty GET + qualifying score shows player", () => {
@@ -183,4 +190,11 @@ test("applyLiveLeaderboardPreviewMerge: skipped after submit or in demo", () => 
 test("normalizeLeaderboardRows: API 3-tuple to internal 4-field row", () => {
   const [r] = normalizeLeaderboardRows([["Ada", 88, "star"]]);
   assert.deepEqual(r, ["Ada", 0, 88, "star"]);
+});
+
+test("normalizeLeaderboardRows: preserves live-preview meta when present", () => {
+  const [r] = normalizeLeaderboardRows([
+    ["Ada", 0, 88, "star", LEADERBOARD_META_LIVE_PREVIEW],
+  ]);
+  assert.deepEqual(r, ["Ada", 0, 88, "star", LEADERBOARD_META_LIVE_PREVIEW]);
 });


### PR DESCRIPTION
- Preserve API rows when merging live preview (no name/score/trophy dedupe on server data).
- Add LEADERBOARD_META_LIVE_PREVIEW on the inserted row; normalize and UI use it for inline edit and submit fallback.
- Second game with identical stats keeps the submitted row above the new preview row.
- Trim redundant JSDoc; single-pass live self-row index lookup.