### PR TITLE
Leaderboard trophy uses highest-scoring word, not longest

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -808,7 +808,7 @@ export function initGame(ctx) {
     updateScore,
     validateWord: (word) => wordSet.has(word.toLowerCase()),
     getWordScoreFromSelectedTiles: (seq) => getLiveWordScoreBreakdown(seq).wordTotal,
-    getLongestWord: () => trophyWord,
+    getTrophyWord: () => trophyWord,
     recordTrophyWordIfBest(word, wordScore) {
       const w = String(word || "");
       const n = Number(wordScore);
@@ -909,7 +909,7 @@ export function initGame(ctx) {
     ctx,
     leaderboardLink,
     getScore: () => score,
-    getLongestWord: () => trophyWord,
+    getTrophyWord: () => trophyWord,
     getLeaderboardPuzzleId: () => leaderboardPuzzleId,
     getScoreValidationTurns: () => scoreValidationTurns,
     getIsMuted: () => isMuted,

--- a/js/game.js
+++ b/js/game.js
@@ -87,7 +87,8 @@ function cloneBoardSnapshotForLeaderboard(board) {
 
 let isMouseDown = false;
 let isGameActive = false;
-let longestWord = "";
+let trophyWord = "";
+let trophyWordScore = Number.NEGATIVE_INFINITY;
 let websiteLink = "https://wordhunter.io/";
 const leaderboardLink = LEADERBOARD_API_BASE;
 let playerPosition;
@@ -807,9 +808,18 @@ export function initGame(ctx) {
     updateScore,
     validateWord: (word) => wordSet.has(word.toLowerCase()),
     getWordScoreFromSelectedTiles: (seq) => getLiveWordScoreBreakdown(seq).wordTotal,
-    getLongestWord: () => longestWord,
-    setLongestWord: (w) => {
-      longestWord = w;
+    getLongestWord: () => trophyWord,
+    recordTrophyWordIfBest(word, wordScore) {
+      const w = String(word || "");
+      const n = Number(wordScore);
+      if (!Number.isFinite(n)) return;
+      if (
+        n > trophyWordScore ||
+        (n === trophyWordScore && w.length > trophyWord.length)
+      ) {
+        trophyWord = w;
+        trophyWordScore = n;
+      }
     },
     addToScore: (delta) => {
       score += delta;
@@ -899,7 +909,7 @@ export function initGame(ctx) {
     ctx,
     leaderboardLink,
     getScore: () => score,
-    getLongestWord: () => longestWord,
+    getLongestWord: () => trophyWord,
     getLeaderboardPuzzleId: () => leaderboardPuzzleId,
     getScoreValidationTurns: () => scoreValidationTurns,
     getIsMuted: () => isMuted,
@@ -1239,7 +1249,8 @@ export function initGame(ctx) {
     playerPosition = undefined;
 
     score = 0;
-    longestWord = "";
+    trophyWord = "";
+    trophyWordScore = Number.NEGATIVE_INFINITY;
 
     resetShiftDragVisualHard();
     grid.style.width = "";
@@ -1339,7 +1350,7 @@ export function initGame(ctx) {
     if (playerPosition) {
       leaderboardText = `#${playerPosition} on `;
     }
-    return `${leaderboardText}wordhunter #${leaderboardPuzzleId} 🏹${score}\n🏆 ${longestWord.toUpperCase()} 🏆\n${websiteLink}`;
+    return `${leaderboardText}wordhunter #${leaderboardPuzzleId} 🏹${score}\n🏆 ${trophyWord.toUpperCase()} 🏆\n${websiteLink}`;
   }
 
   function writeScoreToClipboardPromise() {

--- a/js/leaderboard-lifecycle.js
+++ b/js/leaderboard-lifecycle.js
@@ -20,10 +20,10 @@ export function leaderboardLiveSelfRowIndex(
   rows,
   playerNameValue,
   runScore,
-  longestWord
+  trophyWord
 ) {
   if (!rows?.length) return -1;
-  const trophy = String(longestWord ?? "").trim();
+  const trophy = String(trophyWord ?? "").trim();
   const want = Number(runScore);
   const previewKey = leaderboardPreviewNameKey(playerNameValue);
   let untagged = -1;
@@ -46,10 +46,10 @@ export function leaderboardLiveSubmitNameFallbackRaw(
   rows,
   playerNameValue,
   runScore,
-  longestWord
+  trophyWord
 ) {
   if (!rows?.length) return "";
-  const trophy = String(longestWord ?? "").trim();
+  const trophy = String(trophyWord ?? "").trim();
   const want = Number(runScore);
   const matches = [];
   for (const r of rows) {
@@ -116,7 +116,7 @@ export function applyLiveLeaderboardPreviewMerge(
   normalizedApiRows,
   trimmedPlayerName,
   runScore,
-  longestWord,
+  trophyWord,
   { useDemoData, liveSubmitUsed }
 ) {
   if (useDemoData || liveSubmitUsed) return normalizedApiRows;
@@ -131,7 +131,7 @@ export function applyLiveLeaderboardPreviewMerge(
     normalizedApiRows,
     trimmedPlayerName || "YOU",
     run,
-    String(longestWord || "").trim(),
+    String(trophyWord || "").trim(),
     { dedupeNameScoreTrophy: false, tagLiveRunPreview: true }
   );
 }

--- a/js/leaderboard-live-flow.js
+++ b/js/leaderboard-live-flow.js
@@ -19,7 +19,7 @@ export function deriveLiveLeaderboardAfterFetch(network, input) {
     clicked,
     score,
     nameTrim,
-    longestWord,
+    trophyWord,
     scoreThreshold,
     useDemoData,
     liveSubmitUsed,
@@ -34,7 +34,7 @@ export function deriveLiveLeaderboardAfterFetch(network, input) {
   let tableRows = Array.isArray(fromNetwork) ? fromNetwork : [];
 
   const runPreviewMerge = (norm) =>
-    applyLiveLeaderboardPreviewMerge(norm, trimmedName, score, longestWord, {
+    applyLiveLeaderboardPreviewMerge(norm, trimmedName, score, trophyWord, {
       useDemoData,
       liveSubmitUsed,
     });

--- a/js/leaderboard-ui.js
+++ b/js/leaderboard-ui.js
@@ -53,7 +53,7 @@ export function createLeaderboardController(rt) {
   function findDemoSelfRowIndex() {
     const rows = rt.getDemoRows();
     if (!LEADERBOARD_USE_DEMO_DATA || !rows) return -1;
-    const trophy = String(rt.getLongestWord() || "").trim();
+    const trophy = String(rt.getTrophyWord() || "").trim();
     const want = Number(rt.getScore());
     return rows.findIndex(
       (r) => leaderboardNumericScore(r) === want && String(r[3] || "").trim() === trophy
@@ -65,7 +65,7 @@ export function createLeaderboardController(rt) {
       rt.getLiveLeaderboardPreviewRows?.(),
       refs().playerName.value,
       rt.getScore(),
-      rt.getLongestWord()
+      rt.getTrophyWord()
     );
   }
 
@@ -196,7 +196,7 @@ export function createLeaderboardController(rt) {
         row
       );
       const trophyStr = String(rowTrophy || "").trim();
-      const trophyMatches = trophyStr === String(rt.getLongestWord() || "").trim();
+      const trophyMatches = trophyStr === String(rt.getTrophyWord() || "").trim();
       const isDemoSelfRow =
         LEADERBOARD_USE_DEMO_DATA &&
         hasScore &&
@@ -452,7 +452,7 @@ export function createLeaderboardController(rt) {
         rt.getLiveLeaderboardPreviewRows?.(),
         playerName.value,
         rt.getScore(),
-        rt.getLongestWord()
+        rt.getTrophyWord()
       )
     );
     if (t) playerName.value = t;
@@ -478,7 +478,7 @@ export function createLeaderboardController(rt) {
       clicked,
       score: rt.getScore(),
       nameTrim,
-      longestWord: rt.getLongestWord(),
+      trophyWord: rt.getTrophyWord(),
       scoreThreshold: SCORE_SUBMIT_THRESHOLD,
       useDemoData: LEADERBOARD_USE_DEMO_DATA,
       liveSubmitUsed: rt.getLiveLeaderboardSubmitUsed(),
@@ -499,7 +499,7 @@ export function createLeaderboardController(rt) {
           const postBody = {
             player: nameTrim,
             score: rt.getScore(),
-            trophy: rt.getLongestWord(),
+            trophy: rt.getTrophyWord(),
           };
           if (LEADERBOARD_SUBMIT_SCORE_VALIDATION) {
             postBody.scoreValidation = rt.getScoreValidationTurns();
@@ -577,7 +577,7 @@ export function createLeaderboardController(rt) {
         const run = Number(rt.getScore());
         let rows = [];
         if (demoRunQualifiesForLeaderboard([], run) && run > 0) {
-          rows = mergeDemoRunIntoTop10([], "YOU", run, rt.getLongestWord() || "");
+          rows = mergeDemoRunIntoTop10([], "YOU", run, rt.getTrophyWord() || "");
         }
         rt.setDemoRows(rows);
         renderLeaderboardTable(rows);
@@ -585,7 +585,7 @@ export function createLeaderboardController(rt) {
         const base = buildDemoLeaderboardRows();
         if (demoRunQualifiesForLeaderboard(base, rt.getScore())) {
           rt.setDemoRows(
-            mergeDemoRunIntoTop10(base, "YOU", rt.getScore(), rt.getLongestWord() || "")
+            mergeDemoRunIntoTop10(base, "YOU", rt.getScore(), rt.getTrophyWord() || "")
           );
         } else {
           rt.setDemoRows(base);

--- a/js/word-drag.js
+++ b/js/word-drag.js
@@ -456,9 +456,7 @@ export function createWordDragHandlers(ctx, host) {
             WORD_SUCCESS_MESSAGE_FADE_EARLY_MS
         )
       );
-      if (cw.length >= host.getLongestWord().length) {
-        host.setLongestWord(cw);
-      }
+      host.recordTrophyWordIfBest(cw, wordScore);
       host.updateScore();
 
       applyWordConnectorLineOutcome(true, { huntPaceSuccess: keepingPace });

--- a/tests/leaderboard-mock-api.test.js
+++ b/tests/leaderboard-mock-api.test.js
@@ -10,7 +10,7 @@ const baseInput = {
   scoreThreshold: SCORE_SUBMIT_THRESHOLD,
   useDemoData: false,
   liveSubmitUsed: false,
-  longestWord: "STAR",
+  trophyWord: "STAR",
 };
 
 test("GET [] + qualifying run: preview merge shows player at row 1", () => {


### PR DESCRIPTION
Track single-submit word score for the trophy column and share text. Tie-break equal scores with longer spelling.