### PR TITLE
Leaderboard: base submit eligibility on GET board (pre-preview).

### DIFF
--- a/js/game-endgame.js
+++ b/js/game-endgame.js
@@ -132,6 +132,7 @@ export function createGameEndgameCoordinator(deps) {
     st.demoLeaderboardSubmitUsed = false;
     st.liveLeaderboardSubmitUsed = false;
     st.liveLeaderboardPreviewRows = null;
+    st.liveLeaderboardEligibilityRows = null;
     clearInternalEndgameTimers();
 
     deps.clearTapStreak();

--- a/js/game.js
+++ b/js/game.js
@@ -166,6 +166,7 @@ export function initGame(ctx) {
   const leaderboardRtState = {
     demoLeaderboardRows: null,
     liveLeaderboardPreviewRows: null,
+    liveLeaderboardEligibilityRows: null,
     demoLeaderboardSubmitUsed: false,
     liveLeaderboardSubmitUsed: false,
     playerPosition: undefined,
@@ -976,6 +977,7 @@ export function initGame(ctx) {
     leaderboardRtState.postgameSequenceStarted = false;
     leaderboardRtState.demoLeaderboardRows = null;
     leaderboardRtState.liveLeaderboardPreviewRows = null;
+    leaderboardRtState.liveLeaderboardEligibilityRows = null;
     leaderboardRtState.demoLeaderboardSubmitUsed = false;
     leaderboardRtState.liveLeaderboardSubmitUsed = false;
     if (!skipLeaderboardOverlayTeardown) {

--- a/js/leaderboard-live-flow.js
+++ b/js/leaderboard-live-flow.js
@@ -33,6 +33,10 @@ export function deriveLiveLeaderboardAfterFetch(network, input) {
   const fromNetwork = leaderboardRowsFromResponse(response, payload, canPost);
   let tableRows = Array.isArray(fromNetwork) ? fromNetwork : [];
 
+  const eligibilityRows = useDemoData
+    ? null
+    : padNormalizedLeaderboardToTop10(normalizeLeaderboardRows(tableRows));
+
   const runPreviewMerge = (norm) =>
     applyLiveLeaderboardPreviewMerge(norm, trimmedName, score, trophyWord, {
       useDemoData,
@@ -53,5 +57,5 @@ export function deriveLiveLeaderboardAfterFetch(network, input) {
     tableRows = padNormalizedLeaderboardToTop10(tableRows);
   }
 
-  return { tableRows, committed, canPost };
+  return { tableRows, committed, canPost, eligibilityRows };
 }

--- a/js/leaderboard-ui.js
+++ b/js/leaderboard-ui.js
@@ -327,8 +327,10 @@ export function createLeaderboardController(rt) {
           LEADERBOARD_DEMO_EMPTY_BOARD ? [] : buildDemoLeaderboardRows(),
           rt.getScore()
         )
-      : demoRunQualifiesForLeaderboard(rows, rt.getScore()) &&
-        !st.liveLeaderboardSubmitUsed;
+      : demoRunQualifiesForLeaderboard(
+          st.liveLeaderboardEligibilityRows ?? rows,
+          rt.getScore()
+        ) && !st.liveLeaderboardSubmitUsed;
 
     applyLeaderboardSubmitButtonVisibility({
       leaderboardUseDemoData: LEADERBOARD_USE_DEMO_DATA,
@@ -486,6 +488,7 @@ export function createLeaderboardController(rt) {
     let committed = false;
 
     try {
+      let network;
       try {
         const requestURL = `${rt.leaderboardLink}${rt.getLeaderboardPuzzleId()}`;
         const requestOptions = {
@@ -512,17 +515,16 @@ export function createLeaderboardController(rt) {
         try {
           raw = await response.json();
         } catch {}
-        ({ tableRows, committed } = deriveLiveLeaderboardAfterFetch(
-          { ok: response.ok, status: response.status, raw },
-          deriveInput
-        ));
+        network = { ok: response.ok, status: response.status, raw };
       } catch (err) {
         leaderboardDebugWarn(err);
-        ({ tableRows, committed } = deriveLiveLeaderboardAfterFetch(
-          { ok: false, status: 0, raw: {} },
-          deriveInput
-        ));
+        network = { ok: false, status: 0, raw: {} };
       }
+
+      const resolved = deriveLiveLeaderboardAfterFetch(network, deriveInput);
+      tableRows = resolved.tableRows;
+      committed = resolved.committed;
+      st.liveLeaderboardEligibilityRows = resolved.eligibilityRows;
 
       if (committed) {
         rt.playSound("submit", rt.getIsMuted());

--- a/tests/leaderboard-mock-api.test.js
+++ b/tests/leaderboard-mock-api.test.js
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { SCORE_SUBMIT_THRESHOLD } from "../js/config.js";
 import { deriveLiveLeaderboardAfterFetch } from "../js/leaderboard-live-flow.js";
 import { normalizeLeaderboardRows } from "../js/leaderboard-api.js";
+import { demoRunQualifiesForLeaderboard } from "../js/leaderboard-lifecycle.js";
 
 const EMPTY_PAD = ["", 0, "", ""];
 
@@ -188,4 +189,22 @@ test("Lambda API Gateway envelope: parse body then same commit + rows", () => {
   assert.equal(tableRows.length, 10);
   assert.deepEqual(tableRows[0], ["Ada", 0, 88, "STAR"]);
   assert.deepEqual(tableRows.slice(1), Array(9).fill(EMPTY_PAD));
+});
+
+test("derive: submit cutoff uses GET board before preview merge", () => {
+  const raw = Array.from({ length: 10 }, (_, i) => [`N${i}`, 200 - i * 10, "STAR"]);
+  const { tableRows, eligibilityRows } = deriveLiveLeaderboardAfterFetch(
+    { ok: true, raw },
+    {
+      ...baseInput,
+      clicked: false,
+      score: 115,
+      nameTrim: "",
+      trophyWord: "STAR",
+    }
+  );
+  assert.equal(eligibilityRows[9][2], 110);
+  assert.ok(demoRunQualifiesForLeaderboard(eligibilityRows, 115));
+  assert.equal(tableRows[9][2], 115);
+  assert.equal(demoRunQualifiesForLeaderboard(tableRows, 115), false);
 });


### PR DESCRIPTION
Store eligibilityRows from derive so SUBMIT matches server cutoff when row 10 shows the live preview. Refactor refreshLeaderboardFromApi to a single derive path after fetch or network error. Regression test for merged preview vs cutoff.