### PR TITLE
chore: leaderboard polish, trim unused CSS, fix inline name hard-flag

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -2,7 +2,6 @@ export const greenTextColor = "#07f03a";
 export const redTextColor = "#f76d6d";
 export const lightGreenPreviewColor = "#8ff7a8";
 export const lightRedPreviewColor = "#ff9b9b";
-export const redTextColorLeaderboard = "red";
 export const goldTextColor = "#e3af02";
 export const leaderboardSubPerfectRowColor = "#f5e2a2";
 /** Success message / highlights when the submitted word is the next perfect-hunt list word on pace. */

--- a/js/config.js
+++ b/js/config.js
@@ -4,7 +4,6 @@ export const lightGreenPreviewColor = "#8ff7a8";
 export const lightRedPreviewColor = "#ff9b9b";
 export const redTextColorLeaderboard = "red";
 export const goldTextColor = "#e3af02";
-/** Beige for an entire leaderboard row highlighting the player’s current submission when the run is below perfect hunt (and not hard “red” hunt or doughack). Perfect-hunt Σ and above keeps white row base with gold/over flash on 🏆. */
 export const leaderboardSubPerfectRowColor = "#f5e2a2";
 /** Success message / highlights when the submitted word is the next perfect-hunt list word on pace. */
 export const huntPaceSuccessFlashColor = "#ffdd22";

--- a/js/leaderboard-api.js
+++ b/js/leaderboard-api.js
@@ -1,15 +1,11 @@
 /** Client-only row tag for the current-run preview (never from the API). */
 export const LEADERBOARD_META_LIVE_PREVIEW = "live-preview";
 
+/** Wire rows become `[player, 0, score, trophy]`; index 1 is a legacy slot (formerly hard mode), always zero. */
 export function normalizeLeaderboardRow(row) {
   if (!Array.isArray(row)) return ["", 0, "", ""];
   if (row.length >= 4) {
-    const out = [
-      String(row[0] ?? ""),
-      Number(row[1]) === 1 ? 1 : 0,
-      row[2],
-      String(row[3] ?? ""),
-    ];
+    const out = [String(row[0] ?? ""), 0, row[2], String(row[3] ?? "")];
     if (row[4] === LEADERBOARD_META_LIVE_PREVIEW) {
       out.push(LEADERBOARD_META_LIVE_PREVIEW);
     }

--- a/js/leaderboard-lifecycle.js
+++ b/js/leaderboard-lifecycle.js
@@ -136,7 +136,7 @@ export function mergeDemoRunIntoTop10(baseRows, name, runScore, trophy, mergeOpt
   const filled = baseRows.map((r, idx) => {
     return [
       String(r[0] || ""),
-      Number(r[1]) === 1 ? 1 : 0,
+      0,
       r[2] === "" || r[2] === null || r[2] === undefined ? "" : Number(r[2]),
       String(r[3] || ""),
       idx,

--- a/js/leaderboard-ui-helpers.js
+++ b/js/leaderboard-ui-helpers.js
@@ -8,15 +8,6 @@ export function leaderboardNumericScore(row) {
   return Number(raw);
 }
 
-export function submittingSubPerfectFromRun(perfectTarget, runScoreNum) {
-  return (
-    perfectTarget != null &&
-    Number.isFinite(perfectTarget) &&
-    Number.isFinite(runScoreNum) &&
-    runScoreNum < perfectTarget
-  );
-}
-
 export function rowPerfectOverFlags(perfectTarget, row) {
   const scoreNum = leaderboardNumericScore(row);
   const hasScore = scoreNum !== null;

--- a/js/leaderboard-ui.js
+++ b/js/leaderboard-ui.js
@@ -9,7 +9,6 @@ import {
   CURRENT_WORD_BRIEF_FADE_IN_MS,
   happyHuntingColor,
   leaderboardSubPerfectRowColor,
-  redTextColorLeaderboard,
 } from "./config.js";
 import {
   normalizeLeaderboardRows,
@@ -34,7 +33,6 @@ import { mergeDemoLeaderboardPreviewRows } from "./leaderboard-ui-demo-merge.js"
 import { applyLeaderboardSubmitButtonVisibility } from "./leaderboard-ui-submit-visibility.js";
 import {
   leaderboardNumericScore,
-  submittingSubPerfectFromRun,
   rowPerfectOverFlags,
   setLeaderboardCellFlash,
   syncLeaderboardNameCellSubPerfect,
@@ -81,33 +79,17 @@ export function createLeaderboardController(rt) {
     }
     if (idx < 0 || !rows) return;
     const nameVal = sanitizeDemoLeaderboardName(rows[idx][0]) || "YOU";
-    const row = rows[idx];
-    const perfectTarget = rt.getPerfectHuntTargetSum?.() ?? null;
-    const runScoreNum = Number(rt.getScore());
-    const submittingSubPerfect = submittingSubPerfectFromRun(
-      perfectTarget,
-      runScoreNum
-    );
-    const highlightSelfAllBeigeInline = Number(row[1]) !== 1;
 
     td.textContent = "";
     td.removeAttribute("data-inline-self-name");
     td.classList.add("leaderboard-name-cell--editing-name");
     td.classList.add("leaderboard-name-cell--you-pseudo-select");
-    syncLeaderboardNameCellSubPerfect(
-      td,
-      submittingSubPerfect || highlightSelfAllBeigeInline
-    );
+    syncLeaderboardNameCellSubPerfect(td, true);
 
     const input = document.createElement("input");
     input.type = "text";
-    const inputClasses = ["leaderboard-inline-name-input"];
-    if (submittingSubPerfect || highlightSelfAllBeigeInline) {
-      inputClasses.push("leaderboard-inline-name-input--sub-perfect");
-    } else {
-      inputClasses.push("leaderboard-inline-name-input--player-gold");
-    }
-    input.className = inputClasses.join(" ");
+    input.className =
+      "leaderboard-inline-name-input leaderboard-inline-name-input--sub-perfect";
     input.maxLength = DEMO_LEADERBOARD_NAME_MAX;
     input.setAttribute("inputmode", "text");
     input.setAttribute("pattern", "[A-Za-z]*");
@@ -166,23 +148,19 @@ export function createLeaderboardController(rt) {
     });
     thead.appendChild(headerRow);
 
-    const perfectTarget = rt.getPerfectHuntTargetSum?.() ?? null;
-    const runScoreNum = Number(rt.getScore());
-    const submittingSubPerfect = submittingSubPerfectFromRun(
-      perfectTarget,
-      runScoreNum
-    );
     const typedPlayerName = String(playerName.value || "").trim();
     const typedCanonical = String(
       sanitizeDemoLeaderboardName(typedPlayerName) || typedPlayerName
     ).trim();
     const previewNameKey = leaderboardPreviewNameKey(playerName.value);
 
+    const perfectTarget = rt.getPerfectHuntTargetSum?.() ?? null;
+    const runScoreNum = Number(rt.getScore());
+
     rows.forEach((row, index) => {
-      let [playerRaw, rowHardFlag, , rowTrophy] = row;
+      let [playerRaw, , , rowTrophy] = row;
       const tr = document.createElement("tr");
       let color = "white";
-      const hardFlag = Number(rowHardFlag) === 1 ? 1 : 0;
 
       const playerStr = String(playerRaw || "").trim();
       const scoreNum = leaderboardNumericScore(row);
@@ -253,18 +231,14 @@ export function createLeaderboardController(rt) {
         isLiveSubmittedSelfRow ||
         nameMatchesHighlight;
 
-      const highlightSelfAllBeige = highlightSelfRow && hardFlag !== 1;
-
-      if (hardFlag === 1) {
-        color = redTextColorLeaderboard;
-      } else if (
+      if (
         isDemoSelfRow ||
         isLiveInlineSelfRow ||
         isLiveSubmittedSelfRow ||
         nameMatchesHighlight
       ) {
         st.playerPosition = index + 1;
-        color = highlightSelfAllBeige ? leaderboardSubPerfectRowColor : "white";
+        color = leaderboardSubPerfectRowColor;
       }
 
       tr.style.color = color;
@@ -276,29 +250,24 @@ export function createLeaderboardController(rt) {
           const td = document.createElement("td");
           if (cellIndex === 0) {
             td.textContent = cellText;
-            td.style.color = highlightSelfAllBeige
-              ? leaderboardSubPerfectRowColor
-              : "white";
+            td.style.color = highlightSelfRow ? leaderboardSubPerfectRowColor : "white";
           } else if (cellIndex === 1 && useInlineNameCell) {
             td.dataset.inlineSelfName = "1";
             td.classList.add("leaderboard-name-cell--you-pseudo-select");
-            syncLeaderboardNameCellSubPerfect(
-              td,
-              submittingSubPerfect || highlightSelfAllBeige
-            );
+            syncLeaderboardNameCellSubPerfect(td, true);
             td.style.cursor = "pointer";
-            if (highlightSelfAllBeige) {
+            if (highlightSelfRow) {
               td.style.color = leaderboardSubPerfectRowColor;
             }
             td.textContent = displayNameCell;
           } else if (cellIndex === 1 || cellIndex === 2) {
-            if (highlightSelfAllBeige) {
+            if (highlightSelfRow) {
               td.style.color = leaderboardSubPerfectRowColor;
             }
             td.textContent = cellText;
           } else {
             setLeaderboardCellFlash(td, cellText, nameTrophyFlash);
-            if (highlightSelfAllBeige && String(cellText).trim() !== "") {
+            if (highlightSelfRow && String(cellText).trim() !== "") {
               td.style.color = leaderboardSubPerfectRowColor;
             }
           }

--- a/js/leaderboard-ui.js
+++ b/js/leaderboard-ui.js
@@ -88,21 +88,7 @@ export function createLeaderboardController(rt) {
       perfectTarget,
       runScoreNum
     );
-    const { isPerfectHuntScore, isAbovePerfectHunt } = rowPerfectOverFlags(
-      perfectTarget,
-      row
-    );
-    const nameTrophyFlashInline = isPerfectHuntScore
-      ? "perfect"
-      : isAbovePerfectHunt
-        ? "over"
-        : null;
-    const hardFlagInline = Number(row[1]) === 1 ? 1 : 0;
-    const rawNameLower = String(row[0] || "")
-      .trim()
-      .toLowerCase();
-    const highlightSelfAllBeigeInline =
-      hardFlagInline !== 1 && rawNameLower !== "doughack" && !nameTrophyFlashInline;
+    const highlightSelfAllBeigeInline = Number(row[1]) !== 1;
 
     td.textContent = "";
     td.removeAttribute("data-inline-self-name");
@@ -249,12 +235,7 @@ export function createLeaderboardController(rt) {
             (st.liveLeaderboardSubmitUsed ||
               row[4] === LEADERBOARD_META_LIVE_PREVIEW)));
 
-      let displayPlayer = playerStr;
-      if (playerStr.toLowerCase() === "doughack") {
-        displayPlayer = "doug";
-      }
-
-      const displayNameCell = displayPlayer || "";
+      const displayNameCell = playerStr || "";
       const displayScoreCell = scoreNum === null ? "" : String(scoreNum);
       const displayTrophyCell = isPerfectHuntScore ? "PERFECT HUNT" : trophyStr || "";
       const nameTrophyFlash = isPerfectHuntScore
@@ -272,20 +253,16 @@ export function createLeaderboardController(rt) {
         isLiveSubmittedSelfRow ||
         nameMatchesHighlight;
 
-      const highlightSelfAllBeige =
-        highlightSelfRow &&
-        hardFlag !== 1 &&
-        playerStr.toLowerCase() !== "doughack" &&
-        !nameTrophyFlash;
+      const highlightSelfAllBeige = highlightSelfRow && hardFlag !== 1;
 
       if (hardFlag === 1) {
         color = redTextColorLeaderboard;
-      } else if (isDemoSelfRow || isLiveInlineSelfRow || isLiveSubmittedSelfRow) {
-        st.playerPosition = index + 1;
-        color = highlightSelfAllBeige ? leaderboardSubPerfectRowColor : "white";
-      } else if (playerStr.toLowerCase() === "doughack") {
-        color = "magenta";
-      } else if (nameMatchesHighlight) {
+      } else if (
+        isDemoSelfRow ||
+        isLiveInlineSelfRow ||
+        isLiveSubmittedSelfRow ||
+        nameMatchesHighlight
+      ) {
         st.playerPosition = index + 1;
         color = highlightSelfAllBeige ? leaderboardSubPerfectRowColor : "white";
       }

--- a/style.css
+++ b/style.css
@@ -2,7 +2,6 @@
   --header-control-size: 32px;
   --page-padding: 5px;
   --logo-rules-padding-y: 2px;
-  --page-background-color: #1c1c1e;
   --page-text-color: #ffffff;
   --page-text-shadow-color: black;
   --box-border-color: #3a1f4d;
@@ -63,7 +62,6 @@
   --board-shift-hint-color: #ffffff;
   --board-shift-hint-accent-drag: #2266ee;
   --board-shift-hint-accent-endgame: #dd3333;
-  --board-shift-zone-border-color: rgba(255, 255, 255, 0.2);
   --grid-size: 4;
   --grid-gap: 13px;
   --grid-max: 400px;
@@ -73,12 +71,9 @@
     calc(100vw - 2 * var(--page-padding))
   );
   --radius-sm: 4px;
-  --radius-md: 10px;
   --radius-lg: 14px;
   --dock-min-height: 74px;
-  --space-2xs: 2px;
   --space-xs: 4px;
-  --space-sm: 8px;
   --z-base: 1;
   --z-dock: 2;
   --z-grid-stage: 3;
@@ -1531,11 +1526,6 @@ body.rules-overlay-open #leaderboard-elements {
   border-color: rgba(255, 255, 255, 0.12);
 }
 
-.centered-cell {
-  text-align: center;
-  vertical-align: middle;
-}
-
 #player-name {
   max-height: 26px;
   margin: 0;
@@ -1612,7 +1602,6 @@ body.rules-overlay-open #leaderboard-elements {
   padding: 2px 8px 4px;
   font-size: 0.5rem;
   font-family: "Press Start 2P", cursive;
-  border-top: 1px dashed var(--board-shift-zone-border-color);
 }
 
 #board-shift-zone.visibleDisplay {

--- a/tests/leaderboard-client.test.js
+++ b/tests/leaderboard-client.test.js
@@ -202,6 +202,11 @@ test("normalizeLeaderboardRows: API 3-tuple to internal 4-field row", () => {
   assert.deepEqual(r, ["Ada", 0, 88, "star"]);
 });
 
+test("normalizeLeaderboardRows: legacy 4-tuple hard slot coerced to 0", () => {
+  const [r] = normalizeLeaderboardRows([["Ada", 1, 88, "star"]]);
+  assert.deepEqual(r, ["Ada", 0, 88, "star"]);
+});
+
 test("normalizeLeaderboardRows: preserves live-preview meta when present", () => {
   const [r] = normalizeLeaderboardRows([
     ["Ada", 0, 88, "star", LEADERBOARD_META_LIVE_PREVIEW],


### PR DESCRIPTION
- Beige highlight for preview row includes perfect/over-perfect; drop doughack special-case
- Merge duplicate row color branches; inline edit uses Number(row[1]) for hard flag
- Remove unused CSS vars, centered-cell helper, board-shift dashed border