### PR TITLE
Tidy theme and leaderboard styling.

### DIFF
--- a/js/app-theme.js
+++ b/js/app-theme.js
@@ -3,6 +3,9 @@
 /**
  * Toggles `data-theme` on `<html>`. Night visuals (dock, tiles, background, etc.) live in
  * style.css under `[data-theme="night"]`, not here — keep new theme chrome as CSS overrides.
+ *
+ * Prefer theme-bound colors as CSS custom properties in :root / `[data-theme="night"]`, and
+ * read them via `var(--token)` in styles or inline `style` (see leaderboard self-row).
  */
 
 export const THEME_STORAGE_KEY = "wordhunter_theme";
@@ -19,6 +22,20 @@ export function readStoredTheme() {
     if (raw === "night") return "night";
   } catch (_) {}
   return "default";
+}
+
+/**
+ * @param {HTMLElement | null} [root] Defaults to `document.documentElement`.
+ * @returns {boolean}
+ */
+export function isNightTheme(root = null) {
+  try {
+    const el = root ?? globalThis.document?.documentElement;
+    if (!el) return false;
+    return el.getAttribute("data-theme") === "night";
+  } catch {
+    return false;
+  }
 }
 
 /** @param {HTMLElement | null} root */
@@ -41,7 +58,7 @@ export function applyTheme(theme, opts = {}) {
 
   const btn = opts.toggleButton ?? null;
   if (btn) {
-    const isNight = theme === "night";
+    const isNight = isNightTheme(root);
     btn.textContent = isNight ? THEME_ICON_NIGHT : THEME_ICON_LIGHT;
     btn.setAttribute("aria-pressed", isNight ? "true" : "false");
     btn.setAttribute(

--- a/js/config.js
+++ b/js/config.js
@@ -12,7 +12,6 @@ export function currentWordNeutralTextColor() {
 }
 
 export const goldTextColor = "#e3af02";
-export const leaderboardSubPerfectRowColor = "#f5e2a2";
 /** Success message / highlights when the submitted word is the next perfect-hunt list word on pace. */
 export const huntPaceSuccessFlashColor = "#ffdd22";
 export const happyHuntingColor = "gold";
@@ -113,7 +112,7 @@ export const WORD_RELEASE_GREEN_MS = 255;
 export const WORD_LETTER_FLIP_MS = 416;
 /** Whole-grid exit: `#grid` opacity to 0 (`gridEndgameBatchFade`). Same for regular and perfect hunt. */
 export const ENDGAME_GRID_BATCH_FADE_MS = 1000;
-/** Non-perfect endgame: milliseconds before RETRY is shown (then dock-fade-in). */
+/** Delay before RETRY after non-perfect endgame. */
 export const ENDGAME_RETRY_REVEAL_DELAY_MS = 500;
 export const WORD_REPLACE_FLIP_OVERLAP_MS = Math.floor(WORD_LETTER_FLIP_MS / 2);
 export const WORD_COMMIT_AFTER_PULSE_MS = 300;

--- a/js/config.js
+++ b/js/config.js
@@ -1,3 +1,5 @@
+import { isNightTheme } from "./app-theme.js";
+
 export const greenTextColor = "#07f03a";
 export const redTextColor = "#f76d6d";
 export const lightGreenPreviewColor = "#8ff7a8";
@@ -5,10 +7,7 @@ export const lightRedPreviewColor = "#ff9b9b";
 export const colorSharedWhite = "#f5ecdf";
 
 export function currentWordNeutralTextColor() {
-  if (typeof document === "undefined") return "#ffffff";
-  return document.documentElement.getAttribute("data-theme") === "night"
-    ? colorSharedWhite
-    : "#ffffff";
+  return isNightTheme() ? colorSharedWhite : "#ffffff";
 }
 
 export const goldTextColor = "#e3af02";

--- a/js/leaderboard-ui.js
+++ b/js/leaderboard-ui.js
@@ -8,7 +8,6 @@ import {
   SCORE_SUBMIT_THRESHOLD,
   CURRENT_WORD_BRIEF_FADE_IN_MS,
   happyHuntingColor,
-  leaderboardSubPerfectRowColor,
 } from "./config.js";
 import {
   normalizeLeaderboardRows,
@@ -40,6 +39,8 @@ import {
 } from "./leaderboard-ui-helpers.js";
 import { clearWordLineTimers, fadeInCurrentWordLine } from "./ui-word-line.js";
 import { unlockGameAudio } from "./audio.js";
+
+const LB_SELF_ROW_FG = "var(--leaderboard-self-row-highlight-color)";
 
 function trimLeaderboardSubmitName(raw) {
   return String(sanitizeDemoLeaderboardName(raw) || String(raw ?? "").trim()).trim();
@@ -248,7 +249,7 @@ export function createLeaderboardController(rt) {
         nameMatchesHighlight
       ) {
         st.playerPosition = index + 1;
-        color = leaderboardSubPerfectRowColor;
+        color = LB_SELF_ROW_FG;
       }
 
       tr.style.color = color;
@@ -260,25 +261,25 @@ export function createLeaderboardController(rt) {
           const td = document.createElement("td");
           if (cellIndex === 0) {
             td.textContent = cellText;
-            td.style.color = highlightSelfRow ? leaderboardSubPerfectRowColor : "white";
+            td.style.color = highlightSelfRow ? LB_SELF_ROW_FG : "white";
           } else if (cellIndex === 1 && useInlineNameCell) {
             td.dataset.inlineSelfName = "1";
             td.classList.add("leaderboard-name-cell--you-pseudo-select");
             syncLeaderboardNameCellSubPerfect(td, true);
             td.style.cursor = "pointer";
             if (highlightSelfRow) {
-              td.style.color = leaderboardSubPerfectRowColor;
+              td.style.color = LB_SELF_ROW_FG;
             }
             td.textContent = displayNameCell;
           } else if (cellIndex === 1 || cellIndex === 2) {
             if (highlightSelfRow) {
-              td.style.color = leaderboardSubPerfectRowColor;
+              td.style.color = LB_SELF_ROW_FG;
             }
             td.textContent = cellText;
           } else {
             setLeaderboardCellFlash(td, cellText, nameTrophyFlash);
             if (highlightSelfRow && String(cellText).trim() !== "") {
-              td.style.color = leaderboardSubPerfectRowColor;
+              td.style.color = LB_SELF_ROW_FG;
             }
           }
 

--- a/js/word-path.js
+++ b/js/word-path.js
@@ -1,13 +1,4 @@
-function useNightDragStrokePalette() {
-  try {
-    return (
-      typeof document !== "undefined" &&
-      document.documentElement?.getAttribute("data-theme") === "night"
-    );
-  } catch {
-    return false;
-  }
-}
+import { isNightTheme } from "./app-theme.js";
 
 /**
  * Rainbow gradient for word-drag connector lines. Night mode uses a darker ramp
@@ -20,7 +11,7 @@ export function wordPathDragStrokeColorAt(p) {
   const rRed = 4 / 11;
   const rPink = 7 / 11;
   const rBlue = 9 / 11;
-  const night = useNightDragStrokePalette();
+  const night = isNightTheme();
   const am = night ? { r: 178, g: 128, b: 18 } : { r: 255, g: 175, b: 0 };
   const rd = night ? { r: 168, g: 40, b: 55 } : { r: 255, g: 0, b: 0 };
   const pk = night ? { r: 188, g: 88, b: 148 } : { r: 255, g: 125, b: 195 };

--- a/style.css
+++ b/style.css
@@ -124,6 +124,7 @@
   --tile-invalid-shake-72-fg: #561212;
 }
 
+/* Night: token overrides; prefer new theme colors as --vars in :root or here. */
 [data-theme="night"] {
   --body-background-image: url("images/background2.png");
   --logo-filter: brightness(0) invert(1);
@@ -494,11 +495,11 @@ html {
   display: none;
 }
 
-html[data-theme="night"] .rules-perfect-hunt-pulse-label--day {
+[data-theme="night"] .rules-perfect-hunt-pulse-label--day {
   display: none;
 }
 
-html[data-theme="night"] .rules-perfect-hunt-pulse-label--night {
+[data-theme="night"] .rules-perfect-hunt-pulse-label--night {
   display: inline;
 }
 

--- a/style.css
+++ b/style.css
@@ -109,6 +109,7 @@
   --primary-dock-button-bg: var(--button-background-color);
   --primary-dock-button-text: var(--button-text-color);
   --leaderboard-table-text-color: var(--color-shared-white);
+  --leaderboard-self-row-highlight-color: var(--hunt-pace-highlight-bg);
   --tile-word-release-green-end-bg: #bff9d5;
   --tile-word-release-green-end-fg: #1a4530;
   --tile-invalid-shake-12-bg: #f0a0a0;
@@ -171,8 +172,8 @@
   --page-text-color: var(--color-shared-white);
   --grid-button-inactive-text-color: var(--color-shared-white);
   --rules-accent-red: var(--color-shared-white);
-  --score-muted-label-color: #cab8ea;
-  --rules-section-heading-color: var(--score-muted-label-color);
+  --leaderboard-self-row-highlight-color: #cab8ea;
+  --rules-section-heading-color: var(--leaderboard-self-row-highlight-color);
 }
 
 @media screen and (orientation: landscape) and (hover: none) and (max-width: 960px) {
@@ -1431,11 +1432,6 @@ body.rules-overlay-open #leaderboard-elements {
   text-overflow: ellipsis;
   background-color: transparent;
   vertical-align: middle;
-}
-
-html[data-theme="night"] #leaderboard-table tbody tr,
-html[data-theme="night"] #leaderboard-table tbody td {
-  color: var(--color-shared-white) !important;
 }
 
 #leaderboard-table tbody tr {


### PR DESCRIPTION
Hoist leaderboard self-row fg to a module constant; DRY night lavender for rules headings and row highlight; drop redundant night score-muted duplicate; shorten endgame retry config comment.