### PR TITLE
Fix live leaderboard preview when beating your high score.

### DIFF
--- a/js/leaderboard-lifecycle.js
+++ b/js/leaderboard-lifecycle.js
@@ -21,6 +21,27 @@ export function leaderboardPreviewNameKey(raw) {
   return sanitizeDemoLeaderboardName(t) || t;
 }
 
+/** Best score on eligibility rows for this player key (GET rows before preview merge). */
+export function leaderboardSessionBestScore(rows, playerNameValue) {
+  if (!rows?.length) return null;
+  const playerKey = leaderboardPreviewNameKey(playerNameValue);
+  let best = null;
+  for (const r of rows) {
+    if (leaderboardPreviewNameKey(r[0]) !== playerKey) continue;
+    const s = Number(r[2]);
+    if (!Number.isFinite(s)) continue;
+    if (best === null || s > best) best = s;
+  }
+  return best;
+}
+
+export function leaderboardRunAtOrBelowSessionBest(rows, playerNameValue, runScore) {
+  const sessionBest = leaderboardSessionBestScore(rows, playerNameValue);
+  if (sessionBest === null) return false;
+  const run = Number(runScore);
+  return Number.isFinite(run) && run <= sessionBest;
+}
+
 export function leaderboardLiveSelfRowIndex(
   rows,
   playerNameValue,
@@ -120,7 +141,8 @@ export function applyLiveLeaderboardPreviewMerge(
   const run = Number(runScore);
   if (
     !(Number.isFinite(run) && run > SCORE_SUBMIT_THRESHOLD) ||
-    !demoRunQualifiesForLeaderboard(normalizedApiRows, run)
+    !demoRunQualifiesForLeaderboard(normalizedApiRows, run) ||
+    leaderboardRunAtOrBelowSessionBest(normalizedApiRows, trimmedPlayerName, run)
   ) {
     return normalizedApiRows;
   }

--- a/js/leaderboard-lifecycle.js
+++ b/js/leaderboard-lifecycle.js
@@ -124,12 +124,31 @@ export function applyLiveLeaderboardPreviewMerge(
   ) {
     return normalizedApiRows;
   }
+  const playerKey = leaderboardPreviewNameKey(trimmedPlayerName);
+  let apiRows = normalizedApiRows;
+  if (playerKey) {
+    apiRows = normalizedApiRows.filter((r) => {
+      if (leaderboardPreviewNameKey(r[0]) !== playerKey) return true;
+      const apiScore = Number(r[2]);
+      return !Number.isFinite(apiScore) || apiScore >= run;
+    });
+  } else {
+    apiRows = normalizedApiRows.filter((r) => {
+      if (leaderboardPreviewNameKey(r[0]) !== "") return true;
+      if (r[4] === LEADERBOARD_META_LIVE_PREVIEW) return false;
+      const apiScore = Number(r[2]);
+      return Number.isFinite(apiScore) && apiScore > run;
+    });
+  }
   return mergeDemoRunIntoTop10(
-    normalizedApiRows,
+    apiRows,
     displayName,
     run,
     String(trophyWord || "").trim(),
-    { dedupeNameScoreTrophy: false, tagLiveRunPreview: true }
+    {
+      dedupeNameScoreTrophy: Boolean(playerKey),
+      tagLiveRunPreview: true,
+    }
   );
 }
 

--- a/js/leaderboard-live-flow.js
+++ b/js/leaderboard-live-flow.js
@@ -5,13 +5,33 @@ import {
   leaderboardRowsFromResponse,
   leaderboardPostTreatAsCommitted,
 } from "./leaderboard-api.js";
-import { applyLiveLeaderboardPreviewMerge } from "./leaderboard-lifecycle.js";
+import {
+  applyLiveLeaderboardPreviewMerge,
+  leaderboardRunAtOrBelowSessionBest,
+} from "./leaderboard-lifecycle.js";
 import { isLeaderboardNameAcceptable } from "./leaderboard-name-policy.js";
 
-export function leaderboardCanPostLive(clicked, score, nameTrim, scoreThreshold) {
-  return (
-    clicked && Number(score) > scoreThreshold && isLeaderboardNameAcceptable(nameTrim)
-  );
+export function leaderboardCanPostLive(
+  clicked,
+  score,
+  nameTrim,
+  scoreThreshold,
+  eligibilityRows
+) {
+  if (
+    !clicked ||
+    Number(score) <= scoreThreshold ||
+    !isLeaderboardNameAcceptable(nameTrim)
+  ) {
+    return false;
+  }
+  if (
+    eligibilityRows &&
+    leaderboardRunAtOrBelowSessionBest(eligibilityRows, nameTrim, score)
+  ) {
+    return false;
+  }
+  return true;
 }
 
 export function deriveLiveLeaderboardAfterFetch(network, input) {
@@ -24,10 +44,17 @@ export function deriveLiveLeaderboardAfterFetch(network, input) {
     scoreThreshold,
     useDemoData,
     liveSubmitUsed,
+    priorEligibilityRows,
   } = input;
 
   const trimmedName = String(nameTrim || "").trim();
-  const canPost = leaderboardCanPostLive(clicked, score, trimmedName, scoreThreshold);
+  const canPost = leaderboardCanPostLive(
+    clicked,
+    score,
+    trimmedName,
+    scoreThreshold,
+    priorEligibilityRows
+  );
   const payload = parsedFetchPayload(raw);
   const response = { ok, status: status ?? (ok ? 200 : 400) };
 

--- a/js/leaderboard-ui.js
+++ b/js/leaderboard-ui.js
@@ -23,6 +23,8 @@ import {
   leaderboardLiveSelfRowIndex,
   leaderboardLiveSubmitNameFallbackRaw,
   sanitizeDemoLeaderboardName,
+  leaderboardSessionBestScore,
+  leaderboardRunAtOrBelowSessionBest,
 } from "./leaderboard-lifecycle.js";
 import {
   leaderboardCanPostLive,
@@ -167,6 +169,15 @@ export function createLeaderboardController(rt) {
 
     const perfectTarget = rt.getPerfectHuntTargetSum?.() ?? null;
     const runScoreNum = Number(rt.getScore());
+    const eligibilityForSession = st.liveLeaderboardEligibilityRows ?? rows;
+    const sessionBestScore = LEADERBOARD_USE_DEMO_DATA
+      ? null
+      : leaderboardSessionBestScore(eligibilityForSession, playerName.value);
+    const runBelowSessionBest =
+      !LEADERBOARD_USE_DEMO_DATA &&
+      sessionBestScore !== null &&
+      Number.isFinite(runScoreNum) &&
+      runScoreNum < sessionBestScore;
 
     rows.forEach((row, index) => {
       let [playerRaw, , , rowTrophy] = row;
@@ -198,9 +209,17 @@ export function createLeaderboardController(rt) {
         sameScoreAndTrophyAsRun && rowPreviewNameKey === previewNameKey;
       const isLiveCurrentRunPreviewRow =
         isLiveStatsAndNameMatch && row[4] === LEADERBOARD_META_LIVE_PREVIEW;
+      const isLiveSessionBestRow =
+        !LEADERBOARD_USE_DEMO_DATA &&
+        runBelowSessionBest &&
+        rowPreviewNameKey === previewNameKey &&
+        hasScore &&
+        scoreNum === sessionBestScore &&
+        row[4] !== LEADERBOARD_META_LIVE_PREVIEW;
       const isLiveInlineSelfRow =
         !LEADERBOARD_USE_DEMO_DATA &&
         !st.liveLeaderboardSubmitUsed &&
+        !runBelowSessionBest &&
         isLiveCurrentRunPreviewRow;
       const isLiveSubmittedSelfRow =
         !LEADERBOARD_USE_DEMO_DATA &&
@@ -216,6 +235,7 @@ export function createLeaderboardController(rt) {
       const scoreMatches =
         scoreNum !== null && Number.isFinite(runScoreNum) && scoreNum === runScoreNum;
       const nameMatchesHighlight =
+        !runBelowSessionBest &&
         nameMatches &&
         scoreMatches &&
         trophyMatches &&
@@ -240,12 +260,14 @@ export function createLeaderboardController(rt) {
         isDemoSelfRow ||
         isLiveInlineSelfRow ||
         isLiveSubmittedSelfRow ||
+        isLiveSessionBestRow ||
         nameMatchesHighlight;
 
       if (
         isDemoSelfRow ||
         isLiveInlineSelfRow ||
         isLiveSubmittedSelfRow ||
+        isLiveSessionBestRow ||
         nameMatchesHighlight
       ) {
         st.playerPosition = index + 1;
@@ -296,15 +318,19 @@ export function createLeaderboardController(rt) {
     leaderboardTable.appendChild(thead);
     leaderboardTable.appendChild(tbody);
 
+    const liveEligibility = st.liveLeaderboardEligibilityRows ?? rows;
     const qualifiesForBoardSlot = LEADERBOARD_USE_DEMO_DATA
       ? demoRunQualifiesForLeaderboard(
           LEADERBOARD_DEMO_EMPTY_BOARD ? [] : buildDemoLeaderboardRows(),
           rt.getScore()
         )
-      : demoRunQualifiesForLeaderboard(
-          st.liveLeaderboardEligibilityRows ?? rows,
+      : demoRunQualifiesForLeaderboard(liveEligibility, rt.getScore()) &&
+        !leaderboardRunAtOrBelowSessionBest(
+          liveEligibility,
+          playerName.value,
           rt.getScore()
-        ) && !st.liveLeaderboardSubmitUsed;
+        ) &&
+        !st.liveLeaderboardSubmitUsed;
     st.qualifiesForBoardSlot = qualifiesForBoardSlot;
     applySubmitButtonVisibility();
   }
@@ -440,7 +466,8 @@ export function createLeaderboardController(rt) {
       clicked,
       rt.getScore(),
       nameTrim,
-      SCORE_SUBMIT_THRESHOLD
+      SCORE_SUBMIT_THRESHOLD,
+      st.liveLeaderboardEligibilityRows
     );
     const deriveInput = {
       clicked,
@@ -450,6 +477,7 @@ export function createLeaderboardController(rt) {
       scoreThreshold: SCORE_SUBMIT_THRESHOLD,
       useDemoData: LEADERBOARD_USE_DEMO_DATA,
       liveSubmitUsed: st.liveLeaderboardSubmitUsed,
+      priorEligibilityRows: st.liveLeaderboardEligibilityRows,
     };
     let tableRows;
     let committed = false;

--- a/tests/leaderboard-client.test.js
+++ b/tests/leaderboard-client.test.js
@@ -14,9 +14,13 @@ import {
   demoRunQualifiesForLeaderboard,
   leaderboardLiveSelfRowIndex,
   leaderboardLiveSubmitNameFallbackRaw,
+  leaderboardSessionBestScore,
+  leaderboardRunAtOrBelowSessionBest,
   mergeDemoRunIntoTop10,
 } from "../js/leaderboard-lifecycle.js";
+import { leaderboardCanPostLive } from "../js/leaderboard-live-flow.js";
 import { leaderboardNumericScore } from "../js/leaderboard-ui-helpers.js";
+import { SCORE_SUBMIT_THRESHOLD } from "../js/config.js";
 
 test("top10RowsFromPayload: Flask GET root array and empty POST object", () => {
   assert.deepEqual(top10RowsFromPayload([]), []);
@@ -216,6 +220,63 @@ test("applyLiveLeaderboardPreviewMerge: improved anonymous score replaces prior 
       r[4] === LEADERBOARD_META_LIVE_PREVIEW
   );
   assert.equal(anonRows.length, 1);
+});
+
+test("leaderboardSessionBestScore: named and anonymous keys", () => {
+  const norm = normalizeLeaderboardRows([
+    ["Ada", 88, "STAR"],
+    ["Bob", 100, "STAR"],
+    ["", 70, "STAR"],
+  ]);
+  assert.equal(leaderboardSessionBestScore(norm, "Ada"), 88);
+  assert.equal(leaderboardSessionBestScore(norm, ""), 70);
+  assert.equal(leaderboardSessionBestScore(norm, "Zoe"), null);
+});
+
+test("leaderboardRunAtOrBelowSessionBest: blocks tie and lower retry", () => {
+  const norm = normalizeLeaderboardRows([["Ada", 88, "STAR"]]);
+  assert.equal(leaderboardRunAtOrBelowSessionBest(norm, "Ada", 88), true);
+  assert.equal(leaderboardRunAtOrBelowSessionBest(norm, "Ada", 50), true);
+  assert.equal(leaderboardRunAtOrBelowSessionBest(norm, "Ada", 90), false);
+  assert.equal(leaderboardRunAtOrBelowSessionBest(norm, "Zoe", 90), false);
+});
+
+test("leaderboardCanPostLive: blocks POST at or below session best", () => {
+  const norm = normalizeLeaderboardRows([["Ada", 88, "STAR"]]);
+  assert.equal(
+    leaderboardCanPostLive(true, 50, "Ada", SCORE_SUBMIT_THRESHOLD, norm),
+    false
+  );
+  assert.equal(
+    leaderboardCanPostLive(true, 88, "Ada", SCORE_SUBMIT_THRESHOLD, norm),
+    false
+  );
+  assert.equal(
+    leaderboardCanPostLive(true, 90, "Ada", SCORE_SUBMIT_THRESHOLD, norm),
+    true
+  );
+});
+
+test("applyLiveLeaderboardPreviewMerge: lower retry leaves API rows unchanged", () => {
+  const norm = normalizeLeaderboardRows([
+    ["ADA", 88, "STAR"],
+    ["BOB", 100, "STAR"],
+  ]);
+  const merged = applyLiveLeaderboardPreviewMerge(norm, "Ada", 50, "STAR", {
+    useDemoData: false,
+    liveSubmitUsed: false,
+  });
+  assert.deepEqual(merged, norm);
+  assert.equal(merged.filter((r) => r[4] === LEADERBOARD_META_LIVE_PREVIEW).length, 0);
+});
+
+test("applyLiveLeaderboardPreviewMerge: tie with session best skips preview", () => {
+  const norm = normalizeLeaderboardRows([["ADA", 88, "STAR"]]);
+  const merged = applyLiveLeaderboardPreviewMerge(norm, "Ada", 88, "STAR", {
+    useDemoData: false,
+    liveSubmitUsed: false,
+  });
+  assert.deepEqual(merged, norm);
 });
 
 test("applyLiveLeaderboardPreviewMerge: skipped after submit or in demo", () => {

--- a/tests/leaderboard-client.test.js
+++ b/tests/leaderboard-client.test.js
@@ -185,6 +185,39 @@ test("applyLiveLeaderboardPreviewMerge: empty GET + qualifying score shows playe
   assert.equal(merged.length, 10);
 });
 
+test("applyLiveLeaderboardPreviewMerge: improved self score replaces prior API row", () => {
+  const norm = normalizeLeaderboardRows([
+    ["ADA", 50, "STAR"],
+    ["BOB", 100, "STAR"],
+  ]);
+  const merged = applyLiveLeaderboardPreviewMerge(norm, "Ada", 88, "STAR", {
+    useDemoData: false,
+    liveSubmitUsed: false,
+  });
+  const adaRows = merged.filter((r) => String(r[0]).toUpperCase() === "ADA");
+  assert.equal(adaRows.length, 1);
+  assert.equal(adaRows[0][2], 88);
+  assert.equal(adaRows[0][4], LEADERBOARD_META_LIVE_PREVIEW);
+});
+
+test("applyLiveLeaderboardPreviewMerge: improved anonymous score replaces prior row", () => {
+  const norm = normalizeLeaderboardRows([
+    ["", 50, "STAR"],
+    ["BOB", 100, "STAR"],
+  ]);
+  const merged = applyLiveLeaderboardPreviewMerge(norm, "", 88, "STAR", {
+    useDemoData: false,
+    liveSubmitUsed: false,
+  });
+  const anonRows = merged.filter(
+    (r) =>
+      !String(r[0] ?? "").trim() &&
+      r[2] === 88 &&
+      r[4] === LEADERBOARD_META_LIVE_PREVIEW
+  );
+  assert.equal(anonRows.length, 1);
+});
+
 test("applyLiveLeaderboardPreviewMerge: skipped after submit or in demo", () => {
   const norm = normalizeLeaderboardRows([]);
   const optsA = { useDemoData: false, liveSubmitUsed: true };

--- a/tests/leaderboard-mock-api.test.js
+++ b/tests/leaderboard-mock-api.test.js
@@ -198,6 +198,26 @@ test("Lambda API Gateway envelope: parse body then same commit + rows", () => {
   assert.deepEqual(tableRows.slice(1), Array(9).fill(EMPTY_PAD));
 });
 
+test("derive: improved self score preview replaces prior API row", () => {
+  const raw = [
+    ["Ada", 50, "STAR"],
+    ["Bob", 100, "STAR"],
+  ];
+  const { tableRows } = deriveLiveLeaderboardAfterFetch(
+    { ok: true, raw },
+    {
+      ...baseInput,
+      clicked: false,
+      score: 88,
+      nameTrim: "Ada",
+    }
+  );
+  const adaRows = tableRows.filter((r) => String(r[0]).toUpperCase() === "ADA");
+  assert.equal(adaRows.length, 1);
+  assert.equal(adaRows[0][2], 88);
+  assert.equal(adaRows[0][4], LEADERBOARD_META_LIVE_PREVIEW);
+});
+
 test("derive: submit cutoff uses GET board before preview merge", () => {
   const raw = Array.from({ length: 10 }, (_, i) => [`N${i}`, 200 - i * 10, "STAR"]);
   const { tableRows, eligibilityRows } = deriveLiveLeaderboardAfterFetch(

--- a/tests/leaderboard-mock-api.test.js
+++ b/tests/leaderboard-mock-api.test.js
@@ -1,7 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { SCORE_SUBMIT_THRESHOLD } from "../js/config.js";
-import { deriveLiveLeaderboardAfterFetch } from "../js/leaderboard-live-flow.js";
+import {
+  deriveLiveLeaderboardAfterFetch,
+  leaderboardCanPostLive,
+} from "../js/leaderboard-live-flow.js";
 import {
   normalizeLeaderboardRows,
   LEADERBOARD_META_LIVE_PREVIEW,
@@ -216,6 +219,39 @@ test("derive: improved self score preview replaces prior API row", () => {
   assert.equal(adaRows.length, 1);
   assert.equal(adaRows[0][2], 88);
   assert.equal(adaRows[0][4], LEADERBOARD_META_LIVE_PREVIEW);
+});
+
+test("derive: lower retry keeps API row, no preview merge", () => {
+  const prior = normalizeLeaderboardRows([["Ada", 88, "STAR"]]);
+  const { tableRows, canPost } = deriveLiveLeaderboardAfterFetch(
+    { ok: true, raw: [["Ada", 88, "STAR"]] },
+    {
+      ...baseInput,
+      clicked: false,
+      score: 50,
+      nameTrim: "Ada",
+      priorEligibilityRows: prior,
+    }
+  );
+  assert.equal(canPost, false);
+  assert.equal(tableRows.filter((r) => String(r[0]).toUpperCase() === "ADA").length, 1);
+  assert.equal(tableRows.find((r) => String(r[0]).toUpperCase() === "ADA")[2], 88);
+  assert.equal(
+    tableRows.filter((r) => r[4] === LEADERBOARD_META_LIVE_PREVIEW).length,
+    0
+  );
+});
+
+test("leaderboardCanPostLive: blocks submit when run does not beat session best", () => {
+  const prior = normalizeLeaderboardRows([["Ada", 88, "STAR"]]);
+  assert.equal(
+    leaderboardCanPostLive(true, 50, "Ada", SCORE_SUBMIT_THRESHOLD, prior),
+    false
+  );
+  assert.equal(
+    leaderboardCanPostLive(true, 90, "Ada", SCORE_SUBMIT_THRESHOLD, prior),
+    true
+  );
 });
 
 test("derive: submit cutoff uses GET board before preview merge", () => {


### PR DESCRIPTION
Filter stale self rows from API data before merge so preview shows one updated entry instead of keeping a lower prior score.