### PR TITLE
Restore pre-session leaderboard behavior; set GET cache to 30s.

### DIFF
--- a/js/leaderboard-client.js
+++ b/js/leaderboard-client.js
@@ -1,6 +1,6 @@
 import { leaderboardDebugWarn } from "./leaderboard-api.js";
 
-const LEADERBOARD_FETCH_CACHE_MS = 60_000;
+const LEADERBOARD_FETCH_CACHE_MS = 30_000;
 
 /** @type {Map<string, { fetchedAt: number; result: { ok: boolean; status: number; raw: unknown } }>} */
 const leaderboardFetchCache = new Map();

--- a/js/leaderboard-lifecycle.js
+++ b/js/leaderboard-lifecycle.js
@@ -2,63 +2,6 @@ import { DEMO_LEADERBOARD_NAME_MAX, SCORE_SUBMIT_THRESHOLD } from "./config.js";
 import { LEADERBOARD_META_LIVE_PREVIEW } from "./leaderboard-api.js";
 import { leaderboardNumericScore } from "./leaderboard-ui-helpers.js";
 
-const SUBMIT_NAME_PREFIX = "wordhunter:lb-submit-name:";
-
-/** @type {Map<string, string>} */
-const submitNameMemoryFallback = new Map();
-
-export function resetLeaderboardSubmitNameStorageForTests() {
-  submitNameMemoryFallback.clear();
-  try {
-    if (typeof globalThis.localStorage === "undefined") return;
-    const keys = [];
-    for (let i = 0; i < globalThis.localStorage.length; i += 1) {
-      const key = globalThis.localStorage.key(i);
-      if (key?.startsWith(SUBMIT_NAME_PREFIX)) keys.push(key);
-    }
-    for (const key of keys) globalThis.localStorage.removeItem(key);
-  } catch {
-    // ignore
-  }
-}
-
-/**
- * Last successfully committed leaderboard name for this puzzle (survives reload).
- *
- * @param {number | string} puzzleId
- */
-export function getLeaderboardSubmitName(puzzleId) {
-  const key = `${SUBMIT_NAME_PREFIX}${String(puzzleId)}`;
-  try {
-    if (typeof globalThis.localStorage !== "undefined") {
-      const existing = globalThis.localStorage.getItem(key);
-      if (existing) return existing;
-    }
-  } catch {
-    // fall through to in-memory fallback
-  }
-  return submitNameMemoryFallback.get(key) ?? "";
-}
-
-/**
- * @param {number | string} puzzleId
- * @param {string} nameTrim
- */
-export function setLeaderboardSubmitName(puzzleId, nameTrim) {
-  const key = `${SUBMIT_NAME_PREFIX}${String(puzzleId)}`;
-  const value = String(nameTrim ?? "").trim();
-  if (!value) return;
-  try {
-    if (typeof globalThis.localStorage !== "undefined") {
-      globalThis.localStorage.setItem(key, value);
-      return;
-    }
-  } catch {
-    // fall through to in-memory fallback
-  }
-  submitNameMemoryFallback.set(key, value);
-}
-
 export function sanitizeDemoLeaderboardName(raw) {
   return String(raw || "")
     .replace(/[^a-zA-Z]/g, "")
@@ -76,43 +19,6 @@ export function leaderboardPreviewNameKey(raw) {
   const t = String(raw ?? "").trim();
   if (!t) return "";
   return sanitizeDemoLeaderboardName(t) || t;
-}
-
-/** Best score on eligibility rows for this player key (GET rows before preview merge). */
-export function leaderboardSessionBestScore(
-  rows,
-  playerNameValue,
-  fallbackPlayerNameValue
-) {
-  if (!rows?.length) return null;
-  const keys = [leaderboardPreviewNameKey(playerNameValue)];
-  const fallbackKey = leaderboardPreviewNameKey(fallbackPlayerNameValue);
-  if (fallbackKey && !keys.includes(fallbackKey)) keys.push(fallbackKey);
-  let best = null;
-  for (const r of rows) {
-    const rowKey = leaderboardPreviewNameKey(r[0]);
-    if (!keys.includes(rowKey)) continue;
-    const s = Number(r[2]);
-    if (!Number.isFinite(s)) continue;
-    if (best === null || s > best) best = s;
-  }
-  return best;
-}
-
-export function leaderboardRunAtOrBelowSessionBest(
-  rows,
-  playerNameValue,
-  runScore,
-  fallbackPlayerNameValue
-) {
-  const sessionBest = leaderboardSessionBestScore(
-    rows,
-    playerNameValue,
-    fallbackPlayerNameValue
-  );
-  if (sessionBest === null) return false;
-  const run = Number(runScore);
-  return Number.isFinite(run) && run <= sessionBest;
 }
 
 export function leaderboardLiveSelfRowIndex(
@@ -205,7 +111,7 @@ export function applyLiveLeaderboardPreviewMerge(
   trimmedPlayerName,
   runScore,
   trophyWord,
-  { useDemoData, liveSubmitUsed, fallbackSubmitName }
+  { useDemoData, liveSubmitUsed }
 ) {
   if (useDemoData || liveSubmitUsed) return normalizedApiRows;
   const displayName = sanitizeDemoLeaderboardName(
@@ -214,41 +120,16 @@ export function applyLiveLeaderboardPreviewMerge(
   const run = Number(runScore);
   if (
     !(Number.isFinite(run) && run > SCORE_SUBMIT_THRESHOLD) ||
-    !demoRunQualifiesForLeaderboard(normalizedApiRows, run) ||
-    leaderboardRunAtOrBelowSessionBest(
-      normalizedApiRows,
-      trimmedPlayerName,
-      run,
-      fallbackSubmitName
-    )
+    !demoRunQualifiesForLeaderboard(normalizedApiRows, run)
   ) {
     return normalizedApiRows;
   }
-  const playerKey = leaderboardPreviewNameKey(trimmedPlayerName);
-  let apiRows = normalizedApiRows;
-  if (playerKey) {
-    apiRows = normalizedApiRows.filter((r) => {
-      if (leaderboardPreviewNameKey(r[0]) !== playerKey) return true;
-      const apiScore = Number(r[2]);
-      return !Number.isFinite(apiScore) || apiScore >= run;
-    });
-  } else {
-    apiRows = normalizedApiRows.filter((r) => {
-      if (leaderboardPreviewNameKey(r[0]) !== "") return true;
-      if (r[4] === LEADERBOARD_META_LIVE_PREVIEW) return false;
-      const apiScore = Number(r[2]);
-      return Number.isFinite(apiScore) && apiScore > run;
-    });
-  }
   return mergeDemoRunIntoTop10(
-    apiRows,
+    normalizedApiRows,
     displayName,
     run,
     String(trophyWord || "").trim(),
-    {
-      dedupeNameScoreTrophy: Boolean(playerKey),
-      tagLiveRunPreview: true,
-    }
+    { dedupeNameScoreTrophy: false, tagLiveRunPreview: true }
   );
 }
 

--- a/js/leaderboard-live-flow.js
+++ b/js/leaderboard-live-flow.js
@@ -5,41 +5,13 @@ import {
   leaderboardRowsFromResponse,
   leaderboardPostTreatAsCommitted,
 } from "./leaderboard-api.js";
-import {
-  applyLiveLeaderboardPreviewMerge,
-  leaderboardRunAtOrBelowSessionBest,
-} from "./leaderboard-lifecycle.js";
+import { applyLiveLeaderboardPreviewMerge } from "./leaderboard-lifecycle.js";
 import { isLeaderboardNameAcceptable } from "./leaderboard-name-policy.js";
 
-export function leaderboardCanPostLive(
-  clicked,
-  score,
-  nameTrim,
-  scoreThreshold,
-  eligibilityRows,
-  fallbackSubmitName
-) {
-  if (
-    !clicked ||
-    Number(score) <= scoreThreshold ||
-    !isLeaderboardNameAcceptable(nameTrim)
-  ) {
-    return false;
-  }
-  if (!eligibilityRows) {
-    return false;
-  }
-  if (
-    leaderboardRunAtOrBelowSessionBest(
-      eligibilityRows,
-      nameTrim,
-      score,
-      fallbackSubmitName
-    )
-  ) {
-    return false;
-  }
-  return true;
+export function leaderboardCanPostLive(clicked, score, nameTrim, scoreThreshold) {
+  return (
+    clicked && Number(score) > scoreThreshold && isLeaderboardNameAcceptable(nameTrim)
+  );
 }
 
 export function deriveLiveLeaderboardAfterFetch(network, input) {
@@ -52,19 +24,10 @@ export function deriveLiveLeaderboardAfterFetch(network, input) {
     scoreThreshold,
     useDemoData,
     liveSubmitUsed,
-    priorEligibilityRows,
-    fallbackSubmitName,
   } = input;
 
   const trimmedName = String(nameTrim || "").trim();
-  const canPost = leaderboardCanPostLive(
-    clicked,
-    score,
-    trimmedName,
-    scoreThreshold,
-    priorEligibilityRows,
-    fallbackSubmitName
-  );
+  const canPost = leaderboardCanPostLive(clicked, score, trimmedName, scoreThreshold);
   const payload = parsedFetchPayload(raw);
   const response = { ok, status: status ?? (ok ? 200 : 400) };
 
@@ -79,7 +42,6 @@ export function deriveLiveLeaderboardAfterFetch(network, input) {
     applyLiveLeaderboardPreviewMerge(norm, trimmedName, score, trophyWord, {
       useDemoData,
       liveSubmitUsed,
-      fallbackSubmitName,
     });
 
   if (!useDemoData && !canPost && !liveSubmitUsed) {

--- a/js/leaderboard-ui.js
+++ b/js/leaderboard-ui.js
@@ -23,10 +23,6 @@ import {
   leaderboardLiveSelfRowIndex,
   leaderboardLiveSubmitNameFallbackRaw,
   sanitizeDemoLeaderboardName,
-  leaderboardSessionBestScore,
-  leaderboardRunAtOrBelowSessionBest,
-  getLeaderboardSubmitName,
-  setLeaderboardSubmitName,
 } from "./leaderboard-lifecycle.js";
 import {
   leaderboardCanPostLive,
@@ -53,10 +49,6 @@ function trimLeaderboardSubmitName(raw) {
 export function createLeaderboardController(rt) {
   const refs = () => rt.ctx.refs;
   const st = rt.state;
-
-  function sessionSubmitNameFallback() {
-    return getLeaderboardSubmitName(rt.getLeaderboardPuzzleId());
-  }
 
   function applySubmitButtonVisibility() {
     applyLeaderboardSubmitButtonVisibility({
@@ -171,28 +163,10 @@ export function createLeaderboardController(rt) {
     const typedCanonical = String(
       sanitizeDemoLeaderboardName(typedPlayerName) || typedPlayerName
     ).trim();
-    const sessionNameFallback = sessionSubmitNameFallback();
     const previewNameKey = leaderboardPreviewNameKey(playerName.value);
-    const sessionNameKey = leaderboardPreviewNameKey(sessionNameFallback);
-    const rowMatchesSessionPlayer = (rowKey) =>
-      rowKey === previewNameKey ||
-      (Boolean(sessionNameKey) && rowKey === sessionNameKey);
 
     const perfectTarget = rt.getPerfectHuntTargetSum?.() ?? null;
     const runScoreNum = Number(rt.getScore());
-    const eligibilityForSession = st.liveLeaderboardEligibilityRows ?? rows;
-    const sessionBestScore = LEADERBOARD_USE_DEMO_DATA
-      ? null
-      : leaderboardSessionBestScore(
-          eligibilityForSession,
-          playerName.value,
-          sessionNameFallback
-        );
-    const runBelowSessionBest =
-      !LEADERBOARD_USE_DEMO_DATA &&
-      sessionBestScore !== null &&
-      Number.isFinite(runScoreNum) &&
-      runScoreNum <= sessionBestScore;
 
     rows.forEach((row, index) => {
       let [playerRaw, , , rowTrophy] = row;
@@ -224,17 +198,9 @@ export function createLeaderboardController(rt) {
         sameScoreAndTrophyAsRun && rowPreviewNameKey === previewNameKey;
       const isLiveCurrentRunPreviewRow =
         isLiveStatsAndNameMatch && row[4] === LEADERBOARD_META_LIVE_PREVIEW;
-      const isLiveSessionBestRow =
-        !LEADERBOARD_USE_DEMO_DATA &&
-        runBelowSessionBest &&
-        rowMatchesSessionPlayer(rowPreviewNameKey) &&
-        hasScore &&
-        scoreNum === sessionBestScore &&
-        row[4] !== LEADERBOARD_META_LIVE_PREVIEW;
       const isLiveInlineSelfRow =
         !LEADERBOARD_USE_DEMO_DATA &&
         !st.liveLeaderboardSubmitUsed &&
-        !runBelowSessionBest &&
         isLiveCurrentRunPreviewRow;
       const isLiveSubmittedSelfRow =
         !LEADERBOARD_USE_DEMO_DATA &&
@@ -250,7 +216,6 @@ export function createLeaderboardController(rt) {
       const scoreMatches =
         scoreNum !== null && Number.isFinite(runScoreNum) && scoreNum === runScoreNum;
       const nameMatchesHighlight =
-        !runBelowSessionBest &&
         nameMatches &&
         scoreMatches &&
         trophyMatches &&
@@ -275,14 +240,12 @@ export function createLeaderboardController(rt) {
         isDemoSelfRow ||
         isLiveInlineSelfRow ||
         isLiveSubmittedSelfRow ||
-        isLiveSessionBestRow ||
         nameMatchesHighlight;
 
       if (
         isDemoSelfRow ||
         isLiveInlineSelfRow ||
         isLiveSubmittedSelfRow ||
-        isLiveSessionBestRow ||
         nameMatchesHighlight
       ) {
         st.playerPosition = index + 1;
@@ -333,20 +296,15 @@ export function createLeaderboardController(rt) {
     leaderboardTable.appendChild(thead);
     leaderboardTable.appendChild(tbody);
 
-    const liveEligibility = st.liveLeaderboardEligibilityRows ?? rows;
     const qualifiesForBoardSlot = LEADERBOARD_USE_DEMO_DATA
       ? demoRunQualifiesForLeaderboard(
           LEADERBOARD_DEMO_EMPTY_BOARD ? [] : buildDemoLeaderboardRows(),
           rt.getScore()
         )
-      : demoRunQualifiesForLeaderboard(liveEligibility, rt.getScore()) &&
-        !leaderboardRunAtOrBelowSessionBest(
-          liveEligibility,
-          playerName.value,
-          rt.getScore(),
-          sessionSubmitNameFallback()
-        ) &&
-        !st.liveLeaderboardSubmitUsed;
+      : demoRunQualifiesForLeaderboard(
+          st.liveLeaderboardEligibilityRows ?? rows,
+          rt.getScore()
+        ) && !st.liveLeaderboardSubmitUsed;
     st.qualifiesForBoardSlot = qualifiesForBoardSlot;
     applySubmitButtonVisibility();
   }
@@ -478,14 +436,11 @@ export function createLeaderboardController(rt) {
     }
 
     const nameTrim = resolveLiveLeaderboardNameTrimForSubmit();
-    const fallbackSubmitName = sessionSubmitNameFallback();
     const canPost = leaderboardCanPostLive(
       clicked,
       rt.getScore(),
       nameTrim,
-      SCORE_SUBMIT_THRESHOLD,
-      st.liveLeaderboardEligibilityRows,
-      fallbackSubmitName
+      SCORE_SUBMIT_THRESHOLD
     );
     const deriveInput = {
       clicked,
@@ -495,8 +450,6 @@ export function createLeaderboardController(rt) {
       scoreThreshold: SCORE_SUBMIT_THRESHOLD,
       useDemoData: LEADERBOARD_USE_DEMO_DATA,
       liveSubmitUsed: st.liveLeaderboardSubmitUsed,
-      priorEligibilityRows: st.liveLeaderboardEligibilityRows,
-      fallbackSubmitName,
     };
     let tableRows;
     let committed = false;
@@ -522,7 +475,6 @@ export function createLeaderboardController(rt) {
         rt.playSound("submit", rt.getIsMuted());
         st.liveLeaderboardSubmitUsed = true;
         playerName.value = nameTrim;
-        setLeaderboardSubmitName(rt.getLeaderboardPuzzleId(), nameTrim);
       } else if (clicked) {
         rt.playSound("click", rt.getIsMuted());
       }

--- a/tests/leaderboard-client.test.js
+++ b/tests/leaderboard-client.test.js
@@ -14,13 +14,9 @@ import {
   demoRunQualifiesForLeaderboard,
   leaderboardLiveSelfRowIndex,
   leaderboardLiveSubmitNameFallbackRaw,
-  leaderboardSessionBestScore,
-  leaderboardRunAtOrBelowSessionBest,
   mergeDemoRunIntoTop10,
 } from "../js/leaderboard-lifecycle.js";
-import { leaderboardCanPostLive } from "../js/leaderboard-live-flow.js";
 import { leaderboardNumericScore } from "../js/leaderboard-ui-helpers.js";
-import { SCORE_SUBMIT_THRESHOLD } from "../js/config.js";
 
 test("top10RowsFromPayload: Flask GET root array and empty POST object", () => {
   assert.deepEqual(top10RowsFromPayload([]), []);
@@ -187,123 +183,6 @@ test("applyLiveLeaderboardPreviewMerge: empty GET + qualifying score shows playe
   assert.equal(merged[0][0], "ADA");
   assert.equal(merged[0][2], 88);
   assert.equal(merged.length, 10);
-});
-
-test("applyLiveLeaderboardPreviewMerge: improved self score replaces prior API row", () => {
-  const norm = normalizeLeaderboardRows([
-    ["ADA", 50, "STAR"],
-    ["BOB", 100, "STAR"],
-  ]);
-  const merged = applyLiveLeaderboardPreviewMerge(norm, "Ada", 88, "STAR", {
-    useDemoData: false,
-    liveSubmitUsed: false,
-  });
-  const adaRows = merged.filter((r) => String(r[0]).toUpperCase() === "ADA");
-  assert.equal(adaRows.length, 1);
-  assert.equal(adaRows[0][2], 88);
-  assert.equal(adaRows[0][4], LEADERBOARD_META_LIVE_PREVIEW);
-});
-
-test("applyLiveLeaderboardPreviewMerge: improved anonymous score replaces prior row", () => {
-  const norm = normalizeLeaderboardRows([
-    ["", 50, "STAR"],
-    ["BOB", 100, "STAR"],
-  ]);
-  const merged = applyLiveLeaderboardPreviewMerge(norm, "", 88, "STAR", {
-    useDemoData: false,
-    liveSubmitUsed: false,
-  });
-  const anonRows = merged.filter(
-    (r) =>
-      !String(r[0] ?? "").trim() &&
-      r[2] === 88 &&
-      r[4] === LEADERBOARD_META_LIVE_PREVIEW
-  );
-  assert.equal(anonRows.length, 1);
-});
-
-test("leaderboardSessionBestScore: named and anonymous keys", () => {
-  const norm = normalizeLeaderboardRows([
-    ["Ada", 88, "STAR"],
-    ["Bob", 100, "STAR"],
-    ["", 70, "STAR"],
-  ]);
-  assert.equal(leaderboardSessionBestScore(norm, "Ada"), 88);
-  assert.equal(leaderboardSessionBestScore(norm, ""), 70);
-  assert.equal(leaderboardSessionBestScore(norm, "Zoe"), null);
-});
-
-test("leaderboardRunAtOrBelowSessionBest: blocks tie and lower retry", () => {
-  const norm = normalizeLeaderboardRows([["Ada", 88, "STAR"]]);
-  assert.equal(leaderboardRunAtOrBelowSessionBest(norm, "Ada", 88), true);
-  assert.equal(leaderboardRunAtOrBelowSessionBest(norm, "Ada", 50), true);
-  assert.equal(leaderboardRunAtOrBelowSessionBest(norm, "Ada", 90), false);
-  assert.equal(leaderboardRunAtOrBelowSessionBest(norm, "Zoe", 90), false);
-});
-
-test("leaderboardCanPostLive: blocks POST at or below session best", () => {
-  const norm = normalizeLeaderboardRows([["Ada", 88, "STAR"]]);
-  assert.equal(
-    leaderboardCanPostLive(true, 50, "Ada", SCORE_SUBMIT_THRESHOLD, norm),
-    false
-  );
-  assert.equal(
-    leaderboardCanPostLive(true, 88, "Ada", SCORE_SUBMIT_THRESHOLD, norm),
-    false
-  );
-  assert.equal(
-    leaderboardCanPostLive(true, 90, "Ada", SCORE_SUBMIT_THRESHOLD, norm),
-    true
-  );
-});
-
-test("leaderboardCanPostLive: blocks POST until eligibility rows exist", () => {
-  assert.equal(
-    leaderboardCanPostLive(true, 90, "Ada", SCORE_SUBMIT_THRESHOLD, null),
-    false
-  );
-});
-
-test("leaderboardSessionBestScore: uses stored submit name when field empty", () => {
-  const norm = normalizeLeaderboardRows([["Ada", 100, "STAR"]]);
-  assert.equal(leaderboardSessionBestScore(norm, "", "Ada"), 100);
-  assert.equal(leaderboardRunAtOrBelowSessionBest(norm, "", 50, "Ada"), true);
-});
-
-test("applyLiveLeaderboardPreviewMerge: lower retry blocked via stored submit name", () => {
-  const norm = normalizeLeaderboardRows([
-    ["ADA", 100, "STAR"],
-    ["BOB", 120, "STAR"],
-  ]);
-  const merged = applyLiveLeaderboardPreviewMerge(norm, "", 50, "STAR", {
-    useDemoData: false,
-    liveSubmitUsed: false,
-    fallbackSubmitName: "Ada",
-  });
-  assert.deepEqual(merged, norm);
-  assert.equal(merged.filter((r) => r[4] === LEADERBOARD_META_LIVE_PREVIEW).length, 0);
-});
-
-test("applyLiveLeaderboardPreviewMerge: lower retry leaves API rows unchanged", () => {
-  const norm = normalizeLeaderboardRows([
-    ["ADA", 88, "STAR"],
-    ["BOB", 100, "STAR"],
-  ]);
-  const merged = applyLiveLeaderboardPreviewMerge(norm, "Ada", 50, "STAR", {
-    useDemoData: false,
-    liveSubmitUsed: false,
-  });
-  assert.deepEqual(merged, norm);
-  assert.equal(merged.filter((r) => r[4] === LEADERBOARD_META_LIVE_PREVIEW).length, 0);
-});
-
-test("applyLiveLeaderboardPreviewMerge: tie with session best skips preview", () => {
-  const norm = normalizeLeaderboardRows([["ADA", 88, "STAR"]]);
-  const merged = applyLiveLeaderboardPreviewMerge(norm, "Ada", 88, "STAR", {
-    useDemoData: false,
-    liveSubmitUsed: false,
-  });
-  assert.deepEqual(merged, norm);
 });
 
 test("applyLiveLeaderboardPreviewMerge: skipped after submit or in demo", () => {

--- a/tests/leaderboard-mock-api.test.js
+++ b/tests/leaderboard-mock-api.test.js
@@ -1,10 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { SCORE_SUBMIT_THRESHOLD } from "../js/config.js";
-import {
-  deriveLiveLeaderboardAfterFetch,
-  leaderboardCanPostLive,
-} from "../js/leaderboard-live-flow.js";
+import { deriveLiveLeaderboardAfterFetch } from "../js/leaderboard-live-flow.js";
 import {
   normalizeLeaderboardRows,
   LEADERBOARD_META_LIVE_PREVIEW,
@@ -12,8 +9,6 @@ import {
 import { demoRunQualifiesForLeaderboard } from "../js/leaderboard-lifecycle.js";
 
 const EMPTY_PAD = ["", 0, "", ""];
-
-const EMPTY_ELIGIBILITY = Array(10).fill(EMPTY_PAD);
 
 const baseInput = {
   scoreThreshold: SCORE_SUBMIT_THRESHOLD,
@@ -103,7 +98,6 @@ test("POST success + commit message: rows from top_10, committed", () => {
       clicked: true,
       score: 88,
       nameTrim: "Ada",
-      priorEligibilityRows: EMPTY_ELIGIBILITY,
     }
   );
   assert.equal(canPost, true);
@@ -158,7 +152,6 @@ test("POST 200 root JSON array (same as GET): populates table from response only
       clicked: true,
       score: 88,
       nameTrim: "Ada",
-      priorEligibilityRows: EMPTY_ELIGIBILITY,
     }
   );
   assert.equal(canPost, true);
@@ -177,7 +170,6 @@ test("POST 200 empty object: committed; rows only from server (empty here)", () 
       clicked: true,
       score: 88,
       nameTrim: "Ada",
-      priorEligibilityRows: EMPTY_ELIGIBILITY,
     }
   );
   assert.equal(canPost, true);
@@ -198,135 +190,12 @@ test("Lambda API Gateway envelope: parse body then same commit + rows", () => {
       clicked: true,
       score: 88,
       nameTrim: "Ada",
-      priorEligibilityRows: EMPTY_ELIGIBILITY,
     }
   );
   assert.equal(committed, true);
   assert.equal(tableRows.length, 10);
   assert.deepEqual(tableRows[0], ["Ada", 0, 88, "STAR"]);
   assert.deepEqual(tableRows.slice(1), Array(9).fill(EMPTY_PAD));
-});
-
-test("derive: improved self score preview replaces prior API row", () => {
-  const raw = [
-    ["Ada", 50, "STAR"],
-    ["Bob", 100, "STAR"],
-  ];
-  const { tableRows } = deriveLiveLeaderboardAfterFetch(
-    { ok: true, raw },
-    {
-      ...baseInput,
-      clicked: false,
-      score: 88,
-      nameTrim: "Ada",
-    }
-  );
-  const adaRows = tableRows.filter((r) => String(r[0]).toUpperCase() === "ADA");
-  assert.equal(adaRows.length, 1);
-  assert.equal(adaRows[0][2], 88);
-  assert.equal(adaRows[0][4], LEADERBOARD_META_LIVE_PREVIEW);
-});
-
-test("derive: lower retry keeps API row, no preview merge", () => {
-  const prior = normalizeLeaderboardRows([["Ada", 88, "STAR"]]);
-  const { tableRows, canPost } = deriveLiveLeaderboardAfterFetch(
-    { ok: true, raw: [["Ada", 88, "STAR"]] },
-    {
-      ...baseInput,
-      clicked: false,
-      score: 50,
-      nameTrim: "Ada",
-      priorEligibilityRows: prior,
-    }
-  );
-  assert.equal(canPost, false);
-  assert.equal(tableRows.filter((r) => String(r[0]).toUpperCase() === "ADA").length, 1);
-  assert.equal(tableRows.find((r) => String(r[0]).toUpperCase() === "ADA")[2], 88);
-  assert.equal(
-    tableRows.filter((r) => r[4] === LEADERBOARD_META_LIVE_PREVIEW).length,
-    0
-  );
-});
-
-test("derive: prior submit 100 retry 50 empty name shows only session best", () => {
-  const prior = normalizeLeaderboardRows([["Ada", 100, "STAR"]]);
-  const { tableRows, canPost } = deriveLiveLeaderboardAfterFetch(
-    { ok: true, raw: [["Ada", 100, "STAR"]] },
-    {
-      ...baseInput,
-      clicked: false,
-      score: 50,
-      nameTrim: "",
-      priorEligibilityRows: prior,
-      fallbackSubmitName: "Ada",
-    }
-  );
-  assert.equal(canPost, false);
-  assert.equal(tableRows.filter((r) => String(r[0]).toUpperCase() === "ADA").length, 1);
-  assert.equal(tableRows.find((r) => String(r[0]).toUpperCase() === "ADA")[2], 100);
-  assert.equal(
-    tableRows.filter((r) => r[4] === LEADERBOARD_META_LIVE_PREVIEW).length,
-    0
-  );
-});
-
-test("derive: blocks POST before eligibility rows and on lower retry", () => {
-  assert.equal(
-    deriveLiveLeaderboardAfterFetch(
-      {
-        ok: true,
-        raw: {
-          message: "Record inserted successfully.",
-          top_10: [["Ada", 50, "STAR"]],
-        },
-      },
-      {
-        ...baseInput,
-        clicked: true,
-        score: 50,
-        nameTrim: "Ada",
-        priorEligibilityRows: null,
-      }
-    ).canPost,
-    false
-  );
-  const prior = normalizeLeaderboardRows([["Ada", 100, "STAR"]]);
-  assert.equal(
-    deriveLiveLeaderboardAfterFetch(
-      {
-        ok: true,
-        raw: {
-          message: "Record inserted successfully.",
-          top_10: [["Ada", 50, "STAR"]],
-        },
-      },
-      {
-        ...baseInput,
-        clicked: true,
-        score: 50,
-        nameTrim: "Ada",
-        priorEligibilityRows: prior,
-        fallbackSubmitName: "Ada",
-      }
-    ).canPost,
-    false
-  );
-});
-
-test("leaderboardCanPostLive: blocks submit when run does not beat session best", () => {
-  const prior = normalizeLeaderboardRows([["Ada", 88, "STAR"]]);
-  assert.equal(
-    leaderboardCanPostLive(true, 50, "Ada", SCORE_SUBMIT_THRESHOLD, prior),
-    false
-  );
-  assert.equal(
-    leaderboardCanPostLive(true, 90, "Ada", SCORE_SUBMIT_THRESHOLD, prior),
-    true
-  );
-  assert.equal(
-    leaderboardCanPostLive(true, 50, "", SCORE_SUBMIT_THRESHOLD, prior, "Ada"),
-    false
-  );
 });
 
 test("derive: submit cutoff uses GET board before preview merge", () => {


### PR DESCRIPTION
Revert session-best gating, stale-row preview filtering, and stored submit name logic from leaderboard lifecycle/UI/flow while keeping GA, validation, name policy, and puzzle epoch from 84fb809. Align client fetch cache with 30-second server rate limit.