### PR TITLE
Add 30s submit button cooldown after live leaderboard POST.

### DIFF
--- a/js/game-endgame.js
+++ b/js/game-endgame.js
@@ -11,6 +11,7 @@ import {
   happyHuntingColor,
 } from "./config.js";
 import { pickRandomScenarioMessage } from "./board-logic.js";
+import { clearLiveLeaderboardSubmitCooldown } from "./leaderboard-ui-submit-visibility.js";
 import { clearWordSubmitFeedbackTimer, bumpWordReplaceEpoch } from "./word-drag.js";
 import { getTileText, syncConsumedEmptySlotVisual } from "./grid-tiles.js";
 import { showMessage, getShowMessageDurationMs } from "./ui-word-line.js";
@@ -137,6 +138,7 @@ export function createGameEndgameCoordinator(deps) {
     deps.getLbCtl().hidePostgameLeaderboardOverlay();
     st.demoLeaderboardSubmitUsed = false;
     st.liveLeaderboardSubmitUsed = false;
+    clearLiveLeaderboardSubmitCooldown(st);
     st.liveLeaderboardPreviewRows = null;
     st.liveLeaderboardEligibilityRows = null;
     clearInternalEndgameTimers();

--- a/js/game-player-shell.js
+++ b/js/game-player-shell.js
@@ -9,6 +9,8 @@ export function createPlayerLeaderboardRuntimeState() {
     liveLeaderboardEligibilityRows: null,
     demoLeaderboardSubmitUsed: false,
     liveLeaderboardSubmitUsed: false,
+    liveLeaderboardSubmitCooldownAt: null,
+    liveLeaderboardSubmitCooldownTimer: null,
     playerPosition: undefined,
     postgameCopyScoreTimer: null,
     leaderboardFadeOutTimer: null,

--- a/js/game.js
+++ b/js/game.js
@@ -34,6 +34,7 @@ import {
 import { persistMuted, readStoredMuted } from "./sfx-pref.js";
 import { calculatePuzzleDayIndex, puzzleListIndex } from "./game-lifecycle.js";
 import { createLeaderboardController } from "./leaderboard-ui.js";
+import { clearLiveLeaderboardSubmitCooldown } from "./leaderboard-ui-submit-visibility.js";
 import {
   getTileText,
   setTileText,
@@ -970,6 +971,7 @@ export function initGame(ctx) {
     leaderboardRtState.liveLeaderboardEligibilityRows = null;
     leaderboardRtState.demoLeaderboardSubmitUsed = false;
     leaderboardRtState.liveLeaderboardSubmitUsed = false;
+    clearLiveLeaderboardSubmitCooldown(leaderboardRtState);
     if (!skipLeaderboardOverlayTeardown) {
       lbCtl.hidePostgameLeaderboardOverlay();
     }

--- a/js/leaderboard-client.js
+++ b/js/leaderboard-client.js
@@ -1,6 +1,6 @@
 import { leaderboardDebugWarn } from "./leaderboard-api.js";
 
-const LEADERBOARD_FETCH_CACHE_MS = 30_000;
+export const LEADERBOARD_FETCH_CACHE_MS = 30_000;
 
 /** @type {Map<string, { fetchedAt: number; result: { ok: boolean; status: number; raw: unknown } }>} */
 const leaderboardFetchCache = new Map();

--- a/js/leaderboard-ui-submit-visibility.js
+++ b/js/leaderboard-ui-submit-visibility.js
@@ -1,4 +1,23 @@
+import { LEADERBOARD_FETCH_CACHE_MS } from "./leaderboard-client.js";
 import { leaderboardNameHasLetters } from "./leaderboard-lifecycle.js";
+
+export const LEADERBOARD_SUBMIT_COOLDOWN_MS = LEADERBOARD_FETCH_CACHE_MS;
+
+export function leaderboardSubmitCooldownRemainingMs(
+  lastSubmitAtMs,
+  nowMs = Date.now()
+) {
+  if (lastSubmitAtMs == null || !Number.isFinite(lastSubmitAtMs)) return 0;
+  return Math.max(0, LEADERBOARD_SUBMIT_COOLDOWN_MS - (nowMs - lastSubmitAtMs));
+}
+
+export function clearLiveLeaderboardSubmitCooldown(st) {
+  if (st.liveLeaderboardSubmitCooldownTimer !== null) {
+    globalThis.clearTimeout(st.liveLeaderboardSubmitCooldownTimer);
+    st.liveLeaderboardSubmitCooldownTimer = null;
+  }
+  st.liveLeaderboardSubmitCooldownAt = null;
+}
 
 /**
  * Live submit / demo-add visibility (score threshold vs board eligibility).
@@ -11,6 +30,7 @@ export function applyLeaderboardSubmitButtonVisibility({
   scoreSubmitThreshold,
   liveSubmitUsed,
   demoSubmitUsed,
+  submitCooldownRemainingMs = 0,
 }) {
   const { leaderboardButton, leaderboardDemoAdd, playerName } = refs;
   const nameReady = leaderboardNameHasLetters(playerName?.value);
@@ -68,8 +88,9 @@ export function applyLeaderboardSubmitButtonVisibility({
     "leaderboard-action--concealed",
     !qualifiesForBoardSlot
   );
-  leaderboardButton.disabled = liveSubmitUsed || !nameReady;
-  if (liveSubmitUsed) {
+  const submitCooldownActive = submitCooldownRemainingMs > 0;
+  leaderboardButton.disabled = liveSubmitUsed || !nameReady || submitCooldownActive;
+  if (liveSubmitUsed || submitCooldownActive) {
     leaderboardButton.style.backgroundColor = "rgba(95, 95, 95, 0.92)";
   } else {
     leaderboardButton.style.removeProperty("background-color");

--- a/js/leaderboard-ui.js
+++ b/js/leaderboard-ui.js
@@ -29,7 +29,10 @@ import {
   deriveLiveLeaderboardAfterFetch,
 } from "./leaderboard-live-flow.js";
 import { mergeDemoLeaderboardPreviewRows } from "./leaderboard-ui-demo-merge.js";
-import { applyLeaderboardSubmitButtonVisibility } from "./leaderboard-ui-submit-visibility.js";
+import {
+  applyLeaderboardSubmitButtonVisibility,
+  leaderboardSubmitCooldownRemainingMs,
+} from "./leaderboard-ui-submit-visibility.js";
 import {
   leaderboardNumericScore,
   rowPerfectOverFlags,
@@ -50,6 +53,32 @@ export function createLeaderboardController(rt) {
   const refs = () => rt.ctx.refs;
   const st = rt.state;
 
+  function liveSubmitCooldownRemainingMs() {
+    return leaderboardSubmitCooldownRemainingMs(st.liveLeaderboardSubmitCooldownAt);
+  }
+
+  function clearSubmitCooldownTimer() {
+    if (st.liveLeaderboardSubmitCooldownTimer !== null) {
+      window.clearTimeout(st.liveLeaderboardSubmitCooldownTimer);
+      st.liveLeaderboardSubmitCooldownTimer = null;
+    }
+  }
+
+  function armSubmitCooldownRefresh() {
+    clearSubmitCooldownTimer();
+    const remaining = liveSubmitCooldownRemainingMs();
+    if (remaining <= 0) return;
+    st.liveLeaderboardSubmitCooldownTimer = window.setTimeout(() => {
+      st.liveLeaderboardSubmitCooldownTimer = null;
+      applySubmitButtonVisibility();
+    }, remaining);
+  }
+
+  function markLiveLeaderboardSubmitCooldown() {
+    st.liveLeaderboardSubmitCooldownAt = Date.now();
+    armSubmitCooldownRefresh();
+  }
+
   function applySubmitButtonVisibility() {
     applyLeaderboardSubmitButtonVisibility({
       leaderboardUseDemoData: LEADERBOARD_USE_DEMO_DATA,
@@ -59,6 +88,7 @@ export function createLeaderboardController(rt) {
       scoreSubmitThreshold: SCORE_SUBMIT_THRESHOLD,
       liveSubmitUsed: st.liveLeaderboardSubmitUsed,
       demoSubmitUsed: st.demoLeaderboardSubmitUsed,
+      submitCooldownRemainingMs: liveSubmitCooldownRemainingMs(),
     });
   }
 
@@ -442,6 +472,9 @@ export function createLeaderboardController(rt) {
       nameTrim,
       SCORE_SUBMIT_THRESHOLD
     );
+    if (canPost) {
+      markLiveLeaderboardSubmitCooldown();
+    }
     const deriveInput = {
       clicked,
       score: rt.getScore(),

--- a/tests/leaderboard-submit-cooldown.test.js
+++ b/tests/leaderboard-submit-cooldown.test.js
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  LEADERBOARD_SUBMIT_COOLDOWN_MS,
+  leaderboardSubmitCooldownRemainingMs,
+  clearLiveLeaderboardSubmitCooldown,
+} from "../js/leaderboard-ui-submit-visibility.js";
+import { LEADERBOARD_FETCH_CACHE_MS } from "../js/leaderboard-client.js";
+
+test("leaderboardSubmitCooldownRemainingMs: null or invalid yields 0", () => {
+  const now = 1_700_000_000_000;
+  assert.equal(leaderboardSubmitCooldownRemainingMs(null, now), 0);
+  assert.equal(leaderboardSubmitCooldownRemainingMs(undefined, now), 0);
+  assert.equal(leaderboardSubmitCooldownRemainingMs(Number.NaN, now), 0);
+});
+
+test("leaderboardSubmitCooldownRemainingMs: counts down within window", () => {
+  const now = 1_700_000_000_000;
+  assert.equal(
+    leaderboardSubmitCooldownRemainingMs(now - 5_000, now),
+    LEADERBOARD_SUBMIT_COOLDOWN_MS - 5_000
+  );
+  assert.equal(
+    leaderboardSubmitCooldownRemainingMs(now - LEADERBOARD_SUBMIT_COOLDOWN_MS, now),
+    0
+  );
+  assert.equal(
+    leaderboardSubmitCooldownRemainingMs(now - LEADERBOARD_SUBMIT_COOLDOWN_MS - 1, now),
+    0
+  );
+});
+
+test("submit cooldown duration matches leaderboard fetch cache", () => {
+  assert.equal(LEADERBOARD_SUBMIT_COOLDOWN_MS, LEADERBOARD_FETCH_CACHE_MS);
+});
+
+test("clearLiveLeaderboardSubmitCooldown clears timestamp", () => {
+  const st = {
+    liveLeaderboardSubmitCooldownAt: Date.now(),
+    liveLeaderboardSubmitCooldownTimer: null,
+  };
+  clearLiveLeaderboardSubmitCooldown(st);
+  assert.equal(st.liveLeaderboardSubmitCooldownAt, null);
+  assert.equal(st.liveLeaderboardSubmitCooldownTimer, null);
+});


### PR DESCRIPTION
Align client cooldown with the server rate limit so failed or duplicate submits cannot spam POST; re-enable via existing visibility rules after the window expires.