### PR TITLE
Fix duplicate `tiles` declaration in palette transition.

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -390,8 +390,6 @@ export function initGame(ctx) {
     }
 
     const tiles = gridButtonElements;
-
-    const tiles = gridButtonElements;
     for (let i = 0; i < tiles.length; i++) {
       const el = tiles[i];
       el.classList.remove(


### PR DESCRIPTION
Removes a second `const tiles` in `runGridTilePaletteTransition` that caused a SyntaxError after the game.js refactor.