### PR TITLE
Speed up startup by parallel asset fetch and single-row puzzle parse.

### DIFF
--- a/js/game-lifecycle.js
+++ b/js/game-lifecycle.js
@@ -1,4 +1,4 @@
-import { parsePuzzlesFileText } from "./puzzle-row-format.js";
+import { parsePuzzlesFileTextForPlay } from "./puzzle-row-format.js";
 import {
   decodePuzzleEncFileBase64,
   decryptPuzzleFileBytes,
@@ -63,15 +63,17 @@ async function loadShippedPuzzlesPlaintext() {
 
 /**
  * @returns {Promise<
- *   | { ok: true; wordSet: Set<string>; puzzles: ReturnType<typeof parsePuzzlesFileText> }
+ *   | { ok: true; wordSet: Set<string>; puzzles: ReturnType<typeof parsePuzzlesFileTextForPlay> }
  *   | { ok: false; error: string }
  * >}
  */
 export async function loadWordhunterTextAssets() {
   try {
-    const wordSet = await loadWordlistWordSet();
-    const puzzlesText = await loadShippedPuzzlesPlaintext();
-    const puzzles = parsePuzzlesFileText(puzzlesText, {
+    const [wordSet, puzzlesText] = await Promise.all([
+      loadWordlistWordSet(),
+      loadShippedPuzzlesPlaintext(),
+    ]);
+    const puzzles = parsePuzzlesFileTextForPlay(puzzlesText, {
       fileLabel: "puzzles",
     });
     if (!puzzles.length) {

--- a/js/puzzle-row-format.js
+++ b/js/puzzle-row-format.js
@@ -1,6 +1,7 @@
 /** JSON Lines puzzles. Internal `""` sack slots matter; stripping them loses round-trip data. */
 
 import { PERFECT_HUNT_WORD_COUNT } from "./config.js";
+import { puzzleListIndex } from "./puzzle-calendar.js";
 import {
   stripTrailingEmptyNextLetters,
   canonicalNextLettersFromJsonArray,
@@ -157,53 +158,91 @@ export function serializePuzzleRow(row) {
   return JSON.stringify(packed);
 }
 
-export function parsePuzzlesFileText(text, opts = {}) {
-  const fileLabel = opts.fileLabel ?? "puzzles";
+/**
+ * @param {string} text
+ * @returns {{ lineNo: number; text: string }[]}
+ */
+function collectNonEmptyPuzzleLineRefs(text) {
   const lines = text.split(/\r?\n/);
-  const puzzles = [];
+  /** @type {{ lineNo: number; text: string }[]} */
+  const refs = [];
   let lineNo = 0;
   for (const raw of lines) {
     lineNo++;
     const t = raw.trim();
-    if (!t) continue;
-    let j;
-    try {
-      j = JSON.parse(t);
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      throw new Error(fileLabel + " line " + lineNo + ": " + msg);
-    }
-    const norm = normalizePuzzleRow(j);
-    validatePuzzleRow(norm);
-    /** @type {Record<string, unknown>} */
-    const entry = {
-      starting_grid: norm.starting_grid.map((r) =>
-        /** @type {unknown[]} */ (r).map((c) => String(c || "").toLowerCase())
-      ),
-      next_letters: coerceNextLettersForRow(norm.next_letters),
-      perfect_hunt: /** @type {unknown[]} */ (norm.perfect_hunt).map((w) =>
-        String(w || "").toLowerCase()
-      ),
-    };
-    if (norm.perfect_hunt_starter_flats != null) {
-      entry.perfect_hunt_starter_flats = coerceStarterFlatValues(
-        /** @type {unknown[]} */ (norm.perfect_hunt_starter_flats)
-      );
-    }
-    if (norm.perfect_hunt_starter_tor_neighbors != null) {
-      entry.perfect_hunt_starter_tor_neighbors = coerceStarterTorNeighborsForRow(
-        /** @type {unknown[]} */ (norm.perfect_hunt_starter_tor_neighbors),
-        fileLabel + " line " + lineNo + ": perfect_hunt_starter_tor_neighbors"
-      );
-    }
-    if (norm.perfect_hunt_shifts_before != null) {
-      entry.perfect_hunt_shifts_before = coercePerfectHuntShiftsBefore(
-        norm.perfect_hunt_shifts_before,
-        fileLabel + " line " + lineNo + ": perfect_hunt_shifts_before"
-      );
-    }
-    puzzles.push(entry);
+    if (t) refs.push({ lineNo, text: t });
   }
+  return refs;
+}
+
+/**
+ * @param {string} trimmedLine
+ * @param {number} lineNo
+ * @param {string} fileLabel
+ */
+function parsePuzzleJsonLine(trimmedLine, lineNo, fileLabel) {
+  let j;
+  try {
+    j = JSON.parse(trimmedLine);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new Error(fileLabel + " line " + lineNo + ": " + msg);
+  }
+  const norm = normalizePuzzleRow(j);
+  validatePuzzleRow(norm);
+  /** @type {Record<string, unknown>} */
+  const entry = {
+    starting_grid: norm.starting_grid.map((r) =>
+      /** @type {unknown[]} */ (r).map((c) => String(c || "").toLowerCase())
+    ),
+    next_letters: coerceNextLettersForRow(norm.next_letters),
+    perfect_hunt: /** @type {unknown[]} */ (norm.perfect_hunt).map((w) =>
+      String(w || "").toLowerCase()
+    ),
+  };
+  if (norm.perfect_hunt_starter_flats != null) {
+    entry.perfect_hunt_starter_flats = coerceStarterFlatValues(
+      /** @type {unknown[]} */ (norm.perfect_hunt_starter_flats)
+    );
+  }
+  if (norm.perfect_hunt_starter_tor_neighbors != null) {
+    entry.perfect_hunt_starter_tor_neighbors = coerceStarterTorNeighborsForRow(
+      /** @type {unknown[]} */ (norm.perfect_hunt_starter_tor_neighbors),
+      fileLabel + " line " + lineNo + ": perfect_hunt_starter_tor_neighbors"
+    );
+  }
+  if (norm.perfect_hunt_shifts_before != null) {
+    entry.perfect_hunt_shifts_before = coercePerfectHuntShiftsBefore(
+      norm.perfect_hunt_shifts_before,
+      fileLabel + " line " + lineNo + ": perfect_hunt_shifts_before"
+    );
+  }
+  return entry;
+}
+
+export function parsePuzzlesFileText(text, opts = {}) {
+  const fileLabel = opts.fileLabel ?? "puzzles";
+  const puzzles = [];
+  for (const { lineNo, text: trimmed } of collectNonEmptyPuzzleLineRefs(text)) {
+    puzzles.push(parsePuzzleJsonLine(trimmed, lineNo, fileLabel));
+  }
+  return puzzles;
+}
+
+/**
+ * Play startup: count JSON Lines, parse only today's row. Returns a sparse array
+ * whose `.length` is the shipped row count so `puzzleListIndex(puzzles.length)` matches
+ * the full-file loader.
+ */
+export function parsePuzzlesFileTextForPlay(text, opts = {}) {
+  const fileLabel = opts.fileLabel ?? "puzzles";
+  const refs = collectNonEmptyPuzzleLineRefs(text);
+  if (!refs.length) return [];
+  const idx = puzzleListIndex(refs.length);
+  const entry = parsePuzzleJsonLine(refs[idx].text, refs[idx].lineNo, fileLabel);
+  const puzzles = [];
+  puzzles.length = refs.length;
+  puzzles[idx] = entry;
   return puzzles;
 }
 

--- a/tests/puzzle-row-format.test.js
+++ b/tests/puzzle-row-format.test.js
@@ -5,9 +5,11 @@ import { fileURLToPath } from "node:url";
 import {
   normalizePuzzleRow,
   parsePuzzlesFileText,
+  parsePuzzlesFileTextForPlay,
   dictExportToCanonicalRow,
   serializePuzzleRow,
 } from "../js/puzzle-row-format.js";
+import { puzzleListIndex } from "../js/puzzle-calendar.js";
 import { canonicalNextLettersFromJsonArray } from "../js/puzzle-export-sim.js";
 import {
   PERFECT_HUNT_WORD_COUNT,
@@ -51,6 +53,23 @@ test("parsePuzzlesFileText reads shipped puzzles file", () => {
     assert.equal(p.next_letters.length, NEXT_LETTERS_LEN);
     assert.equal(p.perfect_hunt.length, PERFECT_HUNT_WORD_COUNT);
   }
+});
+
+test("parsePuzzlesFileTextForPlay matches full parse for today's puzzle index", () => {
+  const text = readShippedPuzzlesText();
+  const full = parsePuzzlesFileText(text);
+  const play = parsePuzzlesFileTextForPlay(text);
+  assert.equal(play.length, full.length);
+  const ix = puzzleListIndex(full.length);
+  assert.deepEqual(play[ix], full[ix]);
+  let populated = 0;
+  for (let i = 0; i < play.length; i++) {
+    if (play[i] !== undefined) {
+      populated++;
+      assert.equal(i, ix);
+    }
+  }
+  assert.equal(populated, 1);
 });
 
 test("compact next_letters in JSON pad to NEXT_LETTERS_LEN on load (50 letter tiles)", () => {


### PR DESCRIPTION
Fetch wordlist and puzzles concurrently, and parse only today's puzzle row while preserving sparse array length for daily rotation and share hash.