### PR TITLE
Animate score strip with synchronized flip on word commit.

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -109,6 +109,7 @@ export const GAME_OVER_FLASH_HOLD_EXTRA_MS = 400;
 /** Brief beat after last “GAME OVER” flash before `#grid.grid--endgame-final-fade`. */
 export const ENDGAME_PAUSE_AFTER_GAME_OVER_MESSAGES_MS = 96;
 export const WORD_INVALID_SHAKE_MS = 320;
+export const SCORE_CALC_RESET_MS = 320;
 export const WORD_LINE_FADE_MS = 520;
 export const WORD_PATH_COLOR_STEPS = 11;
 export const WORD_RELEASE_GREEN_MS = 255;

--- a/js/css-vars.js
+++ b/js/css-vars.js
@@ -5,6 +5,7 @@ import {
   CURRENT_WORD_FADE_MS,
   LEADERBOARD_POSTGAME_FADE_MS,
   ENDGAME_GRID_BATCH_FADE_MS,
+  SCORE_CALC_RESET_MS,
 } from "./config.js";
 
 export function syncWordReplaceAnimationCssVars() {
@@ -21,4 +22,5 @@ export function syncWordReplaceAnimationCssVars() {
     "--endgame-grid-batch-fade-ms",
     `${ENDGAME_GRID_BATCH_FADE_MS}ms`
   );
+  root.style.setProperty("--score-calc-reset-ms", `${SCORE_CALC_RESET_MS}ms`);
 }

--- a/js/game-endgame.js
+++ b/js/game-endgame.js
@@ -123,6 +123,7 @@ export function createGameEndgameCoordinator(deps) {
     deps.setIsGameActive(false);
     clearWordSubmitFeedbackTimer(deps.ctx);
     bumpWordReplaceEpoch(deps.ctx);
+    deps.clearScoreCalcHold?.();
     st.endgamePostUiReady = false;
     st.endgameUiShown = false;
     st.copyScoreLineUsed = false;

--- a/js/game-round-reset.js
+++ b/js/game-round-reset.js
@@ -19,6 +19,7 @@ export function resetRoundToPregame(deps, options = {}) {
     generateNextLetters,
     updateNextLetters,
     updateScore,
+    clearScoreCalcHold,
     setRulesOverlayVisible,
     syncLineOverlaySize,
     scheduleSyncLineOverlaySize,
@@ -110,6 +111,7 @@ export function resetRoundToPregame(deps, options = {}) {
   while (gridLineContainer.firstChild) {
     gridLineContainer.firstChild.remove();
   }
+  clearScoreCalcHold?.({ discardPendingScore: true });
   resetSelectionState();
 
   generateGrid();

--- a/js/game.js
+++ b/js/game.js
@@ -14,6 +14,7 @@ import {
   LEADERBOARD_API_BASE,
   LEADERBOARD_OVERLAY_FADE_OUT_TOTAL_MS,
   CHOIR_PLAYBACK_RATES_FOR_RANK,
+  SCORE_CALC_RESET_MS,
 } from "./config.js";
 import {
   getLiveWordScoreBreakdownFromLabels,
@@ -623,6 +624,148 @@ export function initGame(ctx) {
     return getLiveWordScoreBreakdownFromLabels(labels);
   }
 
+  const SCORE_CALC_COMMIT_FLASH_CLASS = "score-value--commit-flash";
+  const SCORE_CALC_RESET_FLIP_CLASS = "score-value--commit-reset-flip";
+  const SCORE_CALC_RESET_FLIP_MID_MS = Math.max(
+    40,
+    Math.floor(SCORE_CALC_RESET_MS / 2)
+  );
+  /** @type {{ letterSum: number; length: number; wordTotal: number } | null} */
+  let scoreCalcHold = null;
+  /** @type {ReturnType<typeof window.setTimeout> | null} */
+  let scoreCalcResetMidTimer = null;
+  /** @type {ReturnType<typeof window.setTimeout> | null} */
+  let scoreCalcResetEndTimer = null;
+  let scoreCalcResetting = false;
+  let pendingWordScoreDelta = 0;
+
+  function scoreCalcFlashElements() {
+    return [scoreSwipeSumElement, scoreLengthElement, scoreWordTotalElement].filter(
+      Boolean
+    );
+  }
+
+  function scoreCalcFlipElements() {
+    return [
+      scoreSwipeSumElement,
+      scoreLengthElement,
+      scoreWordTotalElement,
+      scoreGameTotalElement,
+    ].filter(Boolean);
+  }
+
+  function applyPendingWordScoreToGameTotal() {
+    if (pendingWordScoreDelta === 0) return;
+    score += pendingWordScoreDelta;
+    pendingWordScoreDelta = 0;
+    if (scoreGameTotalElement) {
+      scoreGameTotalElement.textContent = String(score);
+    }
+  }
+
+  function stagePendingWordScoreForGameTotal(delta) {
+    const n = Number(delta);
+    if (!Number.isFinite(n) || n <= 0) return;
+    pendingWordScoreDelta = n;
+  }
+
+  function setScoreCalcFlashActive(active) {
+    for (const el of scoreCalcFlashElements()) {
+      el.classList.toggle(SCORE_CALC_COMMIT_FLASH_CLASS, active);
+    }
+  }
+
+  function setScoreCalcStripToZero() {
+    if (!scoreSwipeSumElement || !scoreLengthElement || !scoreWordTotalElement) {
+      return;
+    }
+    scoreSwipeSumElement.textContent = "0";
+    scoreLengthElement.textContent = "0";
+    scoreWordTotalElement.textContent = "0";
+  }
+
+  function clearScoreCalcResetTimers() {
+    if (scoreCalcResetMidTimer !== null) {
+      window.clearTimeout(scoreCalcResetMidTimer);
+      scoreCalcResetMidTimer = null;
+    }
+    if (scoreCalcResetEndTimer !== null) {
+      window.clearTimeout(scoreCalcResetEndTimer);
+      scoreCalcResetEndTimer = null;
+    }
+  }
+
+  function cancelScoreCalcResetAnimation(options = {}) {
+    const flushPendingScore = options.flushPendingScore !== false;
+    scoreCalcResetting = false;
+    clearScoreCalcResetTimers();
+    for (const el of scoreCalcFlipElements()) {
+      el.classList.remove(SCORE_CALC_RESET_FLIP_CLASS);
+    }
+    if (flushPendingScore) {
+      applyPendingWordScoreToGameTotal();
+    }
+  }
+
+  function scoreCalcStripHeldValuesAreZero() {
+    if (!scoreSwipeSumElement || !scoreLengthElement || !scoreWordTotalElement) {
+      return true;
+    }
+    return (
+      scoreSwipeSumElement.textContent === "0" &&
+      scoreLengthElement.textContent === "0" &&
+      scoreWordTotalElement.textContent === "0"
+    );
+  }
+
+  function holdScoreCalcDuringWordCommit(breakdown) {
+    cancelScoreCalcResetAnimation({ flushPendingScore: scoreCalcResetting });
+    scoreCalcHold = breakdown;
+    setScoreCalcFlashActive(true);
+    updateScoreStrip();
+  }
+
+  function clearScoreCalcHold(options = {}) {
+    const { animate = false, discardPendingScore = false } = options;
+    if (discardPendingScore) {
+      pendingWordScoreDelta = 0;
+    }
+    cancelScoreCalcResetAnimation({
+      flushPendingScore: !animate && !discardPendingScore,
+    });
+    scoreCalcHold = null;
+    setScoreCalcFlashActive(false);
+    if (!scoreSwipeSumElement || !scoreLengthElement || !scoreWordTotalElement) {
+      pendingWordScoreDelta = 0;
+      return;
+    }
+    if (!animate || scoreCalcStripHeldValuesAreZero()) {
+      setScoreCalcStripToZero();
+      return;
+    }
+    scoreCalcResetting = true;
+    const flipEls = scoreCalcFlipElements();
+    for (const el of flipEls) {
+      el.classList.remove(SCORE_CALC_RESET_FLIP_CLASS);
+      void el.offsetWidth;
+      el.classList.add(SCORE_CALC_RESET_FLIP_CLASS);
+    }
+
+    scoreCalcResetMidTimer = window.setTimeout(() => {
+      scoreCalcResetMidTimer = null;
+      setScoreCalcStripToZero();
+      applyPendingWordScoreToGameTotal();
+    }, SCORE_CALC_RESET_FLIP_MID_MS);
+
+    scoreCalcResetEndTimer = window.setTimeout(() => {
+      scoreCalcResetEndTimer = null;
+      scoreCalcResetting = false;
+      for (const el of flipEls) {
+        el.classList.remove(SCORE_CALC_RESET_FLIP_CLASS);
+      }
+    }, SCORE_CALC_RESET_MS);
+  }
+
   function updateScoreStrip() {
     if (
       !scoreSwipeSumElement ||
@@ -632,11 +775,14 @@ export function initGame(ctx) {
     ) {
       return;
     }
-    const live = getLiveWordScoreBreakdown(wordState.selectedButtons);
-    scoreSwipeSumElement.textContent = String(live.letterSum);
-    scoreLengthElement.textContent = String(live.length);
-    scoreWordTotalElement.textContent = String(live.wordTotal);
-    scoreGameTotalElement.textContent = String(score);
+    if (!scoreCalcResetting) {
+      const live =
+        scoreCalcHold ?? getLiveWordScoreBreakdown(wordState.selectedButtons);
+      scoreSwipeSumElement.textContent = String(live.letterSum);
+      scoreLengthElement.textContent = String(live.length);
+      scoreWordTotalElement.textContent = String(live.wordTotal);
+      scoreGameTotalElement.textContent = String(score);
+    }
   }
 
   function updateScore() {
@@ -752,6 +898,11 @@ export function initGame(ctx) {
     updateScoreStrip,
     updateNextLetters,
     updateScore,
+    getLiveWordScoreBreakdownFromSelection: (seq) =>
+      getLiveWordScoreBreakdown(seq ?? wordState.selectedButtons),
+    holdScoreCalcDuringWordCommit,
+    clearScoreCalcHold,
+    queueScoreTotalIncrement: stagePendingWordScoreForGameTotal,
     validateWord: (word) => wordSet.has(word.toLowerCase()),
     getWordScoreFromSelectedTiles: (seq) => getLiveWordScoreBreakdown(seq).wordTotal,
     getTrophyWord: () => trophyWord,
@@ -797,6 +948,7 @@ export function initGame(ctx) {
     getLbCtl: () => lbCtl,
     rtState: leaderboardRtState,
     clearTapStreak,
+    clearScoreCalcHold,
     setRulesOverlayVisible,
     resetSelectionState,
     runGridTilePaletteTransition,
@@ -856,6 +1008,7 @@ export function initGame(ctx) {
         generateNextLetters,
         updateNextLetters,
         updateScore,
+        clearScoreCalcHold,
         setRulesOverlayVisible,
         syncLineOverlaySize,
         scheduleSyncLineOverlaySize,

--- a/js/word-drag.js
+++ b/js/word-drag.js
@@ -140,6 +140,7 @@ export function createWordDragHandlers(ctx, host) {
     const n = tilesToReplace.length;
     const gridN = gridSize;
     if (n === 0) {
+      host.clearScoreCalcHold?.({ animate: true });
       if (collapseNextLetterBlanksAfterFlip) {
         host.collapseNextLetterBlankSlots?.();
       }
@@ -217,6 +218,7 @@ export function createWordDragHandlers(ctx, host) {
 
       const finishWordCommitAnimations = () => {
         if (epoch !== st.wordReplaceEpoch) return;
+        host.clearScoreCalcHold?.({ animate: true });
         if (collapseNextLetterBlanksAfterFlip) {
           host.collapseNextLetterBlankSlots?.();
         }
@@ -441,8 +443,11 @@ export function createWordDragHandlers(ctx, host) {
         });
       }
       const tilesToReplace = Array.from(w().selectedButtonSet);
+      const committedScoreBreakdown = host.getLiveWordScoreBreakdownFromSelection(
+        w().selectedButtons
+      );
       host.recordLeaderboardScoreTurn?.(cw, tilesToReplace.length);
-      host.addToScore(wordScore);
+      host.queueScoreTotalIncrement?.(wordScore);
       const paceOrderResult = host.recordPerfectHuntOrderPace(cw);
       host.commitPerfectHuntWordIfListed(cw);
       showMessage(
@@ -457,7 +462,6 @@ export function createWordDragHandlers(ctx, host) {
         )
       );
       host.recordTrophyWordIfBest(cw, wordScore);
-      host.updateScore();
 
       applyWordConnectorLineOutcome(true, { huntPaceSuccess: keepingPace });
 
@@ -469,6 +473,7 @@ export function createWordDragHandlers(ctx, host) {
       w().selectedButtonSet = new Set();
       w().lastButton = null;
       host.updateCurrentWord();
+      host.holdScoreCalcDuringWordCommit(committedScoreBreakdown);
       host.updateScoreStrip();
       w().currentWord = "";
 

--- a/style.css
+++ b/style.css
@@ -704,6 +704,8 @@ html {
 }
 
 #score .score-value {
+  display: inline-block;
+  transform-origin: center center;
   color: var(--next-letters-text-color);
   text-shadow: 2px 2px 2px var(--next-letters-shadow-color);
   font-size: clamp(0.66rem, 2.9vw, 0.98rem);
@@ -749,6 +751,43 @@ html {
 #score .score-value-total {
   grid-column: 6;
   color: var(--score-accent-gold);
+}
+
+#score .score-value.score-value--commit-flash {
+  color: var(--tile-glyph-white);
+  animation: leaderboardSharedPulse 0.42s ease-in-out infinite;
+}
+
+#score .score-value.score-value--commit-reset-flip {
+  animation: scoreCalcResetFlip var(--score-calc-reset-ms, 320ms)
+    cubic-bezier(0.42, 0, 0.2, 1) forwards;
+}
+
+@keyframes scoreCalcResetFlip {
+  0% {
+    transform: scaleY(1);
+  }
+  50% {
+    transform: scaleY(0.12);
+  }
+  100% {
+    transform: scaleY(1);
+  }
+}
+
+@keyframes scoreCalcResetFade {
+  0% {
+    opacity: 1;
+  }
+  45% {
+    opacity: 0.22;
+  }
+  55% {
+    opacity: 0.22;
+  }
+  100% {
+    opacity: 1;
+  }
 }
 
 #score .score-operator {
@@ -1577,8 +1616,14 @@ body.rules-overlay-open #leaderboard-elements {
   #leaderboard-table .leaderboard-perfect-hunt-flash,
   #leaderboard-table .leaderboard-over-perfect-glow,
   .rules-perfect-hunt-total,
-  .rules-perfect-hunt-pulse-label {
+  .rules-perfect-hunt-pulse-label,
+  #score .score-value.score-value--commit-flash,
+  #score .score-value.score-value--commit-reset-flip {
     animation: none;
+  }
+
+  #score .score-value.score-value--commit-reset-flip {
+    animation: scoreCalcResetFade var(--score-calc-reset-ms, 320ms) ease-in-out forwards;
   }
 
   .grid-button.grid-button--perfect-hunt-hint::before,


### PR DESCRIPTION
Defer game total until tile flips finish, then flip sum, length, word score, and total together to reset the calc row and apply the new total.